### PR TITLE
fix: log the detailed error message for mvn execution failures

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/JavaMavenProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaMavenProvider.java
@@ -58,7 +58,7 @@ public final class JavaMavenProvider extends Provider {
     // check for custom mvn executable
     var mvn = Operations.getCustomPathOrElse("mvn");
     // clean command used to clean build target
-    var mvnCleanCmd = new String[]{mvn, "-q", "clean", "-f", manifestPath.toString()};
+    var mvnCleanCmd = new String[]{mvn, "clean", "-f", manifestPath.toString()};
     var mvnEnvs = getMvnExecEnvs();
     // execute the clean command
     Operations.runProcess(mvnCleanCmd, mvnEnvs);
@@ -67,7 +67,6 @@ public final class JavaMavenProvider extends Provider {
     // the tree command will build the project and create the dependency tree in the temp file
     var mvnTreeCmd = new ArrayList<String>() {{
       add(mvn);
-      add("-q");
       add("dependency:tree");
       add("-DoutputType=dot");
       add("-Dscope=compile");
@@ -144,7 +143,6 @@ public final class JavaMavenProvider extends Provider {
     var tmpEffPom = Files.createTempFile("exhort_eff_pom_", ".xml");
     var mvnEffPomCmd = new String[]{
       mvn,
-      "-q",
       "clean",
       "help:effective-pom",
       String.format("-Doutput=%s", tmpEffPom.toString()),

--- a/src/main/java/com/redhat/exhort/tools/Operations.java
+++ b/src/main/java/com/redhat/exhort/tools/Operations.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /** Utility class used for executing process on the operating system. **/
 public final class Operations {
@@ -97,13 +98,32 @@ public final class Operations {
 
     // verify the command was executed successfully or throw a runtime exception
     if (exitCode != 0) {
-      throw new RuntimeException(
-        String.format(
-          "failed to execute '%s', exit-code %d",
-          String.join(" ", cmdList),
-          exitCode
-        )
-      );
+      String errMsg = new BufferedReader(new InputStreamReader(process.getErrorStream()))
+        .lines().collect(Collectors.joining(System.lineSeparator()));
+      if (errMsg.isEmpty()) {
+        errMsg = new BufferedReader(new InputStreamReader(process.getInputStream()))
+          .lines().collect(Collectors.joining(System.lineSeparator()));
+      }
+      if (errMsg.isEmpty()) {
+        throw new RuntimeException(
+          String.format(
+            "failed to execute '%s', exit-code %d",
+            String.join(" ", cmdList),
+            exitCode
+          )
+        );
+      } else {
+        throw new RuntimeException(
+          String.format(
+            "failed to execute '%s', exit-code %d, message:%s%s%s",
+            String.join(" ", cmdList),
+            exitCode,
+            System.lineSeparator(),
+            errMsg,
+            System.lineSeparator()
+          )
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Description

> Describe what you did and why.

When `mvn` command execution fails, add the output to the exception message. 
So that, the command execution failure details can be found in the IDE (e.g. IntelliJ IDEA) logs, which helps users to troubleshoot the issues.


**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [ ] I have followed this repository's contributing guidelines.
- [ ] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
