### PR TITLE
ci: only create release if the merged branch is prefixed with 'release/'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,9 @@ name: Release Version
 
 on:
   pull_request_target:
-    types:
-      - closed
     branches:
-      - 'release/**'
+      - 'master'
+
 
     paths:
       - "src/main/**"
@@ -16,7 +15,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy release
-    if: github.repository_owner == 'RHEcosystemAppEng'
+#     only trigger the workflow on the base repository and if the merged branch name starts with release.
+    if: github.repository_owner == 'RHEcosystemAppEng' && startsWith(github.head_ref, 'release/')
     outputs:
       project_version: ${{ steps.project.outputs.version }}
     steps:
@@ -55,6 +55,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Release
+    if: github.repository_owner == 'RHEcosystemAppEng' && startsWith(github.head_ref, 'release/')
     environment: staging
     needs: deploy
     steps:


### PR DESCRIPTION
## Description

Trigger the release process only on branches that their name starts with "release/"

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
