### PR TITLE
fix: parsing go module name

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/GoModulesProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/GoModulesProvider.java
@@ -132,8 +132,11 @@ public final class GoModulesProvider extends Provider {
       if (lastSlashIndex == -1)
       {
         String[] splitParts = dependency.split(delimiter);
-        return new PackageURL(Type.GOLANG.getType(), null, splitParts[0], splitParts[1], qualifiers, null);
-
+        if (splitParts.length == 2) {
+          return new PackageURL(Type.GOLANG.getType(), null, splitParts[0], splitParts[1], qualifiers, null);
+        } else {
+          return new PackageURL(Type.GOLANG.getType(), null, splitParts[0], this.mainModuleVersion, qualifiers, null);
+        }
       }
       String namespace = dependency.substring(0, lastSlashIndex);
       String dependencyAndVersion = dependency.substring(lastSlashIndex + 1);

--- a/src/test/java/com/redhat/exhort/providers/Golang_Modules_Provider_Test.java
+++ b/src/test/java/com/redhat/exhort/providers/Golang_Modules_Provider_Test.java
@@ -39,7 +39,8 @@ class Golang_Modules_Provider_Test {
       "go_mod_no_ignore",
       "go_mod_with_ignore",
       "go_mod_with_all_ignore",
-      "go_mod_with_one_ignored_prefix_go"
+      "go_mod_with_one_ignored_prefix_go",
+      "go_mod_no_path"
     );
   }
 

--- a/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_component_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_component_analysis.json
@@ -1,0 +1,57 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2023-09-26T14:28:42Z",
+    "component" : {
+      "name" : "rhda-test",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/rhda-test@v0.0.0",
+      "type" : "application",
+      "bom-ref" : "pkg:golang/rhda-test@v0.0.0"
+    }
+  },
+  "components" : [
+    {
+      "name" : "rhda-test",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/rhda-test@v0.0.0",
+      "type" : "application",
+      "bom-ref" : "pkg:golang/rhda-test@v0.0.0"
+    },
+    {
+      "group" : "github.com/emicklei/go-restful",
+      "name" : "v3",
+      "version" : "v3.0.0",
+      "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0"
+    },
+    {
+      "group" : "github.com/gin-gonic",
+      "name" : "gin",
+      "version" : "v1.7.7",
+      "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:golang/rhda-test@v0.0.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+        "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+      "dependsOn" : [ ]
+    }
+  ]
+}

--- a/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_stack_analysis.json
@@ -1,0 +1,485 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2023-09-26T14:30:10Z",
+    "component" : {
+      "name" : "rhda-test",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/rhda-test@v0.0.0",
+      "type" : "application",
+      "bom-ref" : "pkg:golang/rhda-test@v0.0.0"
+    }
+  },
+  "components" : [
+    {
+      "name" : "rhda-test",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/rhda-test@v0.0.0",
+      "type" : "application",
+      "bom-ref" : "pkg:golang/rhda-test@v0.0.0"
+    },
+    {
+      "group" : "github.com/json-iterator",
+      "name" : "go",
+      "version" : "v1.1.9",
+      "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
+    },
+    {
+      "group" : "github.com/davecgh",
+      "name" : "go-spew",
+      "version" : "v1.1.1",
+      "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "group" : "github.com/google",
+      "name" : "gofuzz",
+      "version" : "v1.0.0",
+      "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
+    },
+    {
+      "group" : "github.com/modern-go",
+      "name" : "concurrent",
+      "version" : "v0.0.0-20180228061459-e0a39a4cb421",
+      "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+    },
+    {
+      "group" : "github.com/modern-go",
+      "name" : "reflect2",
+      "version" : "v0.0.0-20180701023420-4b7aa43c6742",
+      "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+    },
+    {
+      "group" : "github.com/stretchr",
+      "name" : "testify",
+      "version" : "v1.3.0",
+      "purl" : "pkg:golang/github.com/stretchr/testify@v1.3.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.3.0"
+    },
+    {
+      "group" : "github.com/ugorji/go",
+      "name" : "codec",
+      "version" : "v1.1.7",
+      "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+    },
+    {
+      "group" : "github.com/ugorji",
+      "name" : "go",
+      "version" : "v1.1.7",
+      "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "net",
+      "version" : "v0.0.0-20190404232315-eb5bcb51f2a3",
+      "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "crypto",
+      "version" : "v0.0.0-20190308221718-c2843e01d9a2",
+      "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "text",
+      "version" : "v0.3.0",
+      "purl" : "pkg:golang/golang.org/x/text@v0.3.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.0"
+    },
+    {
+      "group" : "github.com/davecgh",
+      "name" : "go-spew",
+      "version" : "v1.1.0",
+      "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.0"
+    },
+    {
+      "group" : "github.com/pmezard",
+      "name" : "go-difflib",
+      "version" : "v1.0.0",
+      "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "group" : "github.com/stretchr",
+      "name" : "objx",
+      "version" : "v0.1.0",
+      "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
+    },
+    {
+      "group" : "github.com/stretchr",
+      "name" : "testify",
+      "version" : "v1.4.0",
+      "purl" : "pkg:golang/github.com/stretchr/testify@v1.4.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.4.0"
+    },
+    {
+      "group" : "gopkg.in",
+      "name" : "yaml.v2",
+      "version" : "v2.2.2",
+      "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+    },
+    {
+      "group" : "github.com/mattn",
+      "name" : "go-isatty",
+      "version" : "v0.0.12",
+      "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "sys",
+      "version" : "v0.0.0-20200116001909-b77594299b42",
+      "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+    },
+    {
+      "group" : "github.com/go-playground/validator",
+      "name" : "v10",
+      "version" : "v10.4.1",
+      "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1"
+    },
+    {
+      "group" : "github.com/go-playground/assert",
+      "name" : "v2",
+      "version" : "v2.0.1",
+      "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+    },
+    {
+      "group" : "github.com/go-playground",
+      "name" : "locales",
+      "version" : "v0.13.0",
+      "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
+    },
+    {
+      "group" : "github.com/go-playground",
+      "name" : "universal-translator",
+      "version" : "v0.17.0",
+      "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+    },
+    {
+      "group" : "github.com/leodido",
+      "name" : "go-urn",
+      "version" : "v1.2.0",
+      "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "crypto",
+      "version" : "v0.0.0-20200622213623-75b288015ac9",
+      "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "sys",
+      "version" : "v0.0.0-20190412213103-97732733099d",
+      "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "text",
+      "version" : "v0.3.2",
+      "purl" : "pkg:golang/golang.org/x/text@v0.3.2",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.2"
+    },
+    {
+      "group" : "golang.org/x",
+      "name" : "tools",
+      "version" : "v0.0.0-20180917221912-90fa682c2a6e",
+      "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+    },
+    {
+      "group" : "github.com/emicklei/go-restful",
+      "name" : "v3",
+      "version" : "v3.0.0",
+      "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0"
+    },
+    {
+      "group" : "github.com/gin-gonic",
+      "name" : "gin",
+      "version" : "v1.7.7",
+      "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+    },
+    {
+      "group" : "github.com/gin-contrib",
+      "name" : "sse",
+      "version" : "v0.1.0",
+      "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+    },
+    {
+      "group" : "gopkg.in",
+      "name" : "check.v1",
+      "version" : "v0.0.0-20161208181325-20d25e280405",
+      "purl" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+    },
+    {
+      "group" : "github.com/golang",
+      "name" : "protobuf",
+      "version" : "v1.3.3",
+      "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
+    },
+    {
+      "group" : "gopkg.in",
+      "name" : "yaml.v2",
+      "version" : "v2.2.8",
+      "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "type" : "library",
+      "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:golang/rhda-test@v0.0.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+        "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "dependsOn" : [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.0.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+        "pkg:golang/github.com/stretchr/testify@v1.3.0"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/stretchr/testify@v1.3.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "dependsOn" : [
+        "pkg:golang/github.com/ugorji/go@v1.1.7"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "dependsOn" : [
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+      "dependsOn" : [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/text@v0.3.0"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/text@v0.3.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/stretchr/testify@v1.4.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+      "dependsOn" : [
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "dependsOn" : [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+      "dependsOn" : [
+        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+        "pkg:golang/github.com/go-playground/locales@v0.13.0",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "dependsOn" : [
+        "pkg:golang/golang.org/x/text@v0.3.2"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/go-playground/locales@v0.13.0"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/stretchr/testify@v1.4.0"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+      "dependsOn" : [
+        "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/text@v0.3.2",
+      "dependsOn" : [
+        "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+      "dependsOn" : [
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+        "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/json-iterator/go@v1.1.9",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/github.com/stretchr/testify@v1.4.0",
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "dependsOn" : [
+        "pkg:golang/github.com/stretchr/testify@v1.3.0"
+      ]
+    },
+    {
+      "ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "dependsOn" : [
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+      ]
+    }
+  ]
+}

--- a/src/test/resources/tst_manifests/golang/go_mod_no_path/go.mod
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_path/go.mod
@@ -1,0 +1,10 @@
+module rhda-test
+
+go 1.12
+
+require (
+	github.com/gin-gonic/gin v1.7.7
+    github.com/emicklei/go-restful/v3 v3.0.0
+)
+
+replace github.com/emicklei/go-restful/v3 => github.com/emicklei/go-restful/v3 v3.0.0


### PR DESCRIPTION
## Description

Fix a scenario of parsing module name in go.mod, for example: https://github.com/pstember/go-goof/blob/73c2655d0f64cbd4ce8793d9819215ea337b8156/go.mod#L1


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
