### PR TITLE
feat: get output of pip commands from env variables

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/PythonPipProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/PythonPipProvider.java
@@ -36,8 +36,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.redhat.exhort.impl.ExhortApi.debugLoggingIsNeeded;
-import static com.redhat.exhort.impl.ExhortApi.getBooleanValueEnvironment;
+import static com.redhat.exhort.impl.ExhortApi.*;
 
 public final class PythonPipProvider extends Provider {
 
@@ -222,11 +221,24 @@ public final class PythonPipProvider extends Provider {
   }
 
   private PythonControllerBase getPythonController() {
-    String pythonPipBinaries = getPythonPipBinaries();
+    String pythonPipBinaries;
+    String useVirtualPythonEnv;
+    if(!getStringValueEnvironment("EXHORT_PIP_SHOW","").trim().equals("")
+       && !getStringValueEnvironment("EXHORT_PIP_FREEZE","").trim().equals("")) {
+      pythonPipBinaries = "python;;pip";
+      useVirtualPythonEnv = "false";
+    }
+    else {
+      pythonPipBinaries = getPythonPipBinaries();
+      useVirtualPythonEnv = Objects.requireNonNullElseGet(
+        System.getenv("EXHORT_PYTHON_VIRTUAL_ENV"),
+        () -> Objects.requireNonNullElse(System.getProperty("EXHORT_PYTHON_VIRTUAL_ENV"), "false"));
+    }
+
     String[] parts = pythonPipBinaries.split(";;");
     var python = parts[0];
     var pip = parts[1];
-    String useVirtualPythonEnv = Objects.requireNonNullElseGet(
+    useVirtualPythonEnv = Objects.requireNonNullElseGet(
       System.getenv("EXHORT_PYTHON_VIRTUAL_ENV"),
       () -> Objects.requireNonNullElse(System.getProperty("EXHORT_PYTHON_VIRTUAL_ENV"), "false"));
     PythonControllerBase pythonController;


### PR DESCRIPTION
## Description

Implement [PR #92](https://github.com/RHEcosystemAppEng/exhort-javascript-api/pull/92/) for Java-API 

Developed to ease and make life easier for running rhda analysis for python pip requirements.txt manifest, as every requirements.txt with certain versions for its package is tailored for a certain python version. 
This enables  separating the installation of the requirements.txt from the machine that runs the RHDA analysis ( will be used mainly from jenkins pipelines together with RHDA Jenkins pipeline).

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.


