### PR TITLE
feat: add exhort client trace id to API library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>${jakarta.annotation-api.version}</version>
@@ -179,6 +184,8 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
+
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/src/main/java/com/redhat/exhort/impl/ClientTraceIdSimpleFormatter.java
+++ b/src/main/java/com/redhat/exhort/impl/ClientTraceIdSimpleFormatter.java
@@ -1,11 +1,136 @@
+/*
+ * Copyright © 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.redhat.exhort.impl;
 
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 
 public class ClientTraceIdSimpleFormatter extends SimpleFormatter {
+
+
+  private final ObjectMapper objectMapper;
+
+  public ClientTraceIdSimpleFormatter() {
+    this.objectMapper = new ObjectMapper();
+    this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
   @Override
   public String format(LogRecord record) {
-    return String.format("%s, ex-client-trace-id: %s",super.format(record).trim(),RequestManager.getInstance().getTraceIdOfRequest() + System.lineSeparator());
+//    return String.format("%s, ex-client-trace-id: %s",super.format(record).trim(),RequestManager.getInstance().getTraceIdOfRequest() + System.lineSeparator());
+    Map<String,Object> messageKeysValues = new HashMap<>();
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(
+      record.getInstant(), ZoneId.systemDefault());
+    String source;
+    if (record.getSourceClassName() != null) {
+      source = record.getSourceClassName();
+      if (record.getSourceMethodName() != null) {
+        source += " " + record.getSourceMethodName();
+      }
+    } else {
+      source = record.getLoggerName();
+    }
+    String message = formatMessage(record);
+    String throwable = "";
+    if (record.getThrown() != null) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      pw.println();
+      record.getThrown().printStackTrace(pw);
+      pw.close();
+      throwable = sw.toString();
+    }
+//    return String.format(super.format,
+//                         zdt,
+//                         source,
+//                         record.getLoggerName(),
+//                         record.getLevel().getLocalizedLevelName(),
+//                         message,
+//                         throwable);
+    messageKeysValues.put("timestamp",zdt.toString());
+    messageKeysValues.put("ex-client-trace-id",RequestManager.getInstance().getTraceIdOfRequest());
+    messageKeysValues.put("methodName",source);
+    messageKeysValues.put("loggerName",record.getLoggerName());
+    messageKeysValues.put("logLevel",record.getLevel().toString());
+    String jsonPartOfMessage = getJsonPartOfMessage(message);
+    if(isValidJson(jsonPartOfMessage) || messageContainsOutputStructure(message)) {
+      messageKeysValues.put("logMessage", "log Message Contains a structure , and it will follow after the log entry");
+    }
+    else {
+      messageKeysValues.put("logMessage", message);
+    }
+    try {
+      String jsonLogRecord = objectMapper.writeValueAsString(messageKeysValues) + System.lineSeparator();
+      return jsonLogRecord + suffixRequired(messageKeysValues,message);
+    } catch (JsonProcessingException e) {
+      return String.format("%s, ex-client-trace-id: %s",super.format(record).trim(),RequestManager.getInstance().getTraceIdOfRequest() + System.lineSeparator());
+    }
+  }
+
+  private String suffixRequired(Map<String, Object> messageKeysValues, String message) {
+    if(((String)messageKeysValues.get("logMessage")).trim().contains("log Message Contains a structure")) {
+      return message.trim() + System.lineSeparator();
+    }
+    else {
+      return "";
+    }
+  }
+  private boolean messageContainsOutputStructure(String message)
+  {
+    String messageWithLC = message.toLowerCase();
+    return messageWithLC.contains("package manager") && messageWithLC.contains("output");
+  }
+  private boolean isValidJson(String jsonPartOfMessage) {
+    if (Objects.isNull(jsonPartOfMessage)) {
+      return false;
+    }
+    try {
+      objectMapper.readTree(jsonPartOfMessage);
+    } catch (JacksonException e) {
+      return false;
+    }
+    return true;
+  }
+
+  private String getJsonPartOfMessage(String message) {
+    int startOfJson = message.indexOf("{");
+    int endOfJson = message.lastIndexOf("}");
+    if( startOfJson > -1 && endOfJson > 0) {
+      return message.substring(startOfJson,endOfJson + 1);
+    }
+    else {
+      return null;
+    }
+
+
   }
 }

--- a/src/main/java/com/redhat/exhort/impl/ClientTraceIdSimpleFormatter.java
+++ b/src/main/java/com/redhat/exhort/impl/ClientTraceIdSimpleFormatter.java
@@ -1,0 +1,11 @@
+package com.redhat.exhort.impl;
+
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
+
+public class ClientTraceIdSimpleFormatter extends SimpleFormatter {
+  @Override
+  public String format(LogRecord record) {
+    return String.format("%s, ex-client-trace-id: %s",super.format(record).trim(),RequestManager.getInstance().getTraceIdOfRequest() + System.lineSeparator());
+  }
+}

--- a/src/main/java/com/redhat/exhort/impl/ExhortApi.java
+++ b/src/main/java/com/redhat/exhort/impl/ExhortApi.java
@@ -38,10 +38,10 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.redhat.exhort.Api;
 import com.redhat.exhort.Provider;
 import com.redhat.exhort.api.AnalysisReport;
+import com.redhat.exhort.logging.LoggersFactory;
 import com.redhat.exhort.tools.Ecosystem;
 
 import jakarta.mail.MessagingException;
@@ -55,7 +55,10 @@ public final class ExhortApi implements Api {
 
 //  private static final System.Logger LOG = System.getLogger(ExhortApi.class.getName());
 
-  private static final Logger LOG = Logger.getLogger(ExhortApi.class.getName());
+  private static final Logger LOG = LoggersFactory.getLogger(ExhortApi.class.getName());
+
+
+
   public static final String DEFAULT_ENDPOINT = "https://rhda.rhcloud.com";
   public static final String DEFAULT_ENDPOINT_DEV = "https://exhort.stage.devshift.net";
   public static final String RHDA_TOKEN_HEADER = "rhda-token";
@@ -72,7 +75,7 @@ public final class ExhortApi implements Api {
   public static final void main(String[] args) throws IOException, InterruptedException, ExecutionException {
     System.setProperty("EXHORT_DEV_MODE", "true");
     AnalysisReport analysisReport = new ExhortApi()
-      .componentAnalysis("/tmp/node-express-hello-devfile-no-dockerfile/package.json").get();
+      .stackAnalysis("/home/zgrinber/git/exhort-java-api/src/test/resources/tst_manifests/maven/deps_with_ignore_on_artifact/pom.xml").get();
 //    ObjectMapper om = new ObjectMapper().configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
 //    System.out.println(om.writerWithDefaultPrettyPrinter().writeValueAsString(analysisReport));
 //    AnalysisReport analysisReport = new ExhortApi()

--- a/src/main/java/com/redhat/exhort/impl/ExhortApi.java
+++ b/src/main/java/com/redhat/exhort/impl/ExhortApi.java
@@ -313,7 +313,7 @@ public final class ExhortApi implements Api {
 
   private static void logExhortRequestId(HttpResponse response) {
     Optional<String> headerExRequestId = response.headers().allValues(EXHORT_REQUEST_ID_HEADER_NAME).stream().findFirst();
-    headerExRequestId.ifPresent(value -> LOG.info(String.format("Unique Identifier associated with this request - ex-request-id= : %s", value)));
+    headerExRequestId.ifPresent(value -> LOG.info(String.format("Unique Identifier associated with this request ( Received from Exhort Backend ) - ex-request-id= : %s", value)));
   }
 
   public static boolean debugLoggingIsNeeded() {

--- a/src/main/java/com/redhat/exhort/impl/RequestManager.java
+++ b/src/main/java/com/redhat/exhort/impl/RequestManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.exhort.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class RequestManager {
+
+
+  private static RequestManager requestManager;
+  private Map<String,String> requests;
+
+  public static RequestManager getInstance()
+  {
+    if(Objects.isNull(requestManager)) {
+      requestManager = new RequestManager();
+    }
+    return requestManager;
+  }
+
+  private RequestManager()
+  {
+    requests = new HashMap<>();
+  }
+
+  public synchronized void addClientTraceIdToRequest(String requestId) {
+    requests.put(Thread.currentThread().getName(),requestId);
+  }
+
+  public synchronized void removeClientTraceIdFromRequest() {
+    requests.remove(Thread.currentThread().getName());
+  }
+
+  public String getTraceIdOfRequest() {
+    return requests.get(Thread.currentThread().getName());
+  }
+
+}

--- a/src/main/java/com/redhat/exhort/logging/LoggersFactory.java
+++ b/src/main/java/com/redhat/exhort/logging/LoggersFactory.java
@@ -1,0 +1,2 @@
+package com.redhat.exhort.logging;public class LoggersFactory {
+}

--- a/src/main/java/com/redhat/exhort/logging/LoggersFactory.java
+++ b/src/main/java/com/redhat/exhort/logging/LoggersFactory.java
@@ -1,2 +1,18 @@
-package com.redhat.exhort.logging;public class LoggersFactory {
+package com.redhat.exhort.logging;
+
+import com.redhat.exhort.impl.ClientTraceIdSimpleFormatter;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Logger;
+
+public class LoggersFactory {
+  public static Logger getLogger(String loggerName) {
+    Logger logger = Logger.getLogger(loggerName);
+    ConsoleHandler handler = new ConsoleHandler();
+    handler.setFormatter(new ClientTraceIdSimpleFormatter());
+    logger.addHandler(handler);
+    logger.setUseParentHandlers(false);
+    return logger;
+
+  }
 }

--- a/src/main/java/com/redhat/exhort/logging/LoggersFactory.java
+++ b/src/main/java/com/redhat/exhort/logging/LoggersFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.redhat.exhort.logging;
 
 import com.redhat.exhort.impl.ClientTraceIdSimpleFormatter;

--- a/src/main/java/com/redhat/exhort/providers/GoModulesProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/GoModulesProvider.java
@@ -21,6 +21,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.redhat.exhort.Api;
 import com.redhat.exhort.Provider;
+import com.redhat.exhort.logging.LoggersFactory;
 import com.redhat.exhort.sbom.Sbom;
 import com.redhat.exhort.sbom.SbomFactory;
 import com.redhat.exhort.tools.Ecosystem.Type;
@@ -35,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -49,7 +51,7 @@ import static com.redhat.exhort.impl.ExhortApi.getBooleanValueEnvironment;
  **/
 public final class GoModulesProvider extends Provider {
 
-  private System.Logger log = System.getLogger(this.getClass().getName());
+  private Logger log = LoggersFactory.getLogger(this.getClass().getName());
   private static final String goHostArchitectureEnvName = "GOHOSTARCH";
   private static final String goHostOperationSystemEnvName = "GOHOSTOS";
   public static final String defaultMainVersion = "v0.0.0";
@@ -424,7 +426,7 @@ public final class GoModulesProvider extends Provider {
     // execute the clean command
     String goModulesOutput = Operations.runProcessGetOutput(manifestPath.getParent(),goModulesDeps);
     if(debugLoggingIsNeeded()) {
-      log.log(System.Logger.Level.INFO,String.format("Go Mod Graph : %s %s",System.lineSeparator(),goModulesOutput));
+      log.info(String.format("Package Manager Go Mod Graph output : %s%s",System.lineSeparator(),goModulesOutput));
     }
     return goModulesOutput;
   }

--- a/src/main/java/com/redhat/exhort/providers/JavaMavenProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaMavenProvider.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,6 +36,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.redhat.exhort.Api;
 import com.redhat.exhort.Provider;
+import com.redhat.exhort.logging.LoggersFactory;
 import com.redhat.exhort.sbom.Sbom;
 import com.redhat.exhort.sbom.SbomFactory;
 import com.redhat.exhort.tools.Ecosystem;
@@ -50,7 +52,7 @@ import static com.redhat.exhort.impl.ExhortApi.debugLoggingIsNeeded;
  **/
 public final class JavaMavenProvider extends Provider {
 
-  private System.Logger log = System.getLogger(this.getClass().getName());
+  private Logger log = LoggersFactory.getLogger(this.getClass().getName());
   public static void main(String[] args) throws IOException {
     JavaMavenProvider javaMavenProvider = new JavaMavenProvider();
     PackageURL packageURL = javaMavenProvider.parseDep("+- org.assertj:assertj-core:jar:3.24.2:test");
@@ -104,9 +106,10 @@ public final class JavaMavenProvider extends Provider {
     if(debugLoggingIsNeeded())
     {
       String stackAnalysisDependencyTree = Files.readString(tmpFile);
-      log.log(System.Logger.Level.INFO,String.format("Maven Stack Analysis Dependency Tree : %s %s",System.lineSeparator(),stackAnalysisDependencyTree));
+      log.info(String.format("Package Manager Maven Stack Analysis Dependency Tree Output: %s %s",System.lineSeparator(),stackAnalysisDependencyTree));
     }
     var sbom = buildSbomFromTextFormat(tmpFile);
+    // build and return content for constructing request to the backend
     // build and return content for constructing request to the backend
     return new Content(sbom.filterIgnoredDeps(ignored).getAsJsonString().getBytes(), Api.CYCLONEDX_MEDIA_TYPE);
   }
@@ -315,7 +318,7 @@ public final class JavaMavenProvider extends Provider {
     if(debugLoggingIsNeeded())
     {
       String CaEffectivePoM = Files.readString(tmpEffPom);
-      log.log(System.Logger.Level.INFO,String.format("Maven Component Analysis Effective POM : %s %s",System.lineSeparator(),CaEffectivePoM));
+      log.info(String.format("Package Manager Maven Component Analysis Effective POM Output : %s %s",System.lineSeparator(),CaEffectivePoM));
     }
     // if we have dependencies marked as ignored grab ignored dependencies from the original pom
     // the effective-pom goal doesn't carry comments

--- a/src/main/java/com/redhat/exhort/providers/PythonPipProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/PythonPipProvider.java
@@ -20,6 +20,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.redhat.exhort.Api;
 import com.redhat.exhort.Provider;
+import com.redhat.exhort.logging.LoggersFactory;
 import com.redhat.exhort.sbom.Sbom;
 import com.redhat.exhort.sbom.SbomFactory;
 import com.redhat.exhort.tools.Ecosystem;
@@ -34,13 +35,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static com.redhat.exhort.impl.ExhortApi.*;
 
 public final class PythonPipProvider extends Provider {
 
-  private System.Logger log = System.getLogger(this.getClass().getName());
+  private Logger log = LoggersFactory.getLogger(this.getClass().getName());
   public void setPythonController(PythonControllerBase pythonController) {
     this.pythonController = pythonController;
   }
@@ -135,7 +137,7 @@ public final class PythonPipProvider extends Provider {
   private void printDependenciesTree(List<Map<String, Object>> dependencies) throws JsonProcessingException {
     if(debugLoggingIsNeeded()) {
       String pythonControllerTree = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dependencies);
-      log.log(System.Logger.Level.INFO,String.format("Python Generated Dependency Tree in Json Format: %s %s %s",System.lineSeparator(),pythonControllerTree,System.lineSeparator()));
+      log.info(String.format("Python Generated Dependency Tree in Json Format: %s %s %s",System.lineSeparator(),pythonControllerTree,System.lineSeparator()));
 
     }
   }

--- a/src/main/java/com/redhat/exhort/sbom/CycloneDXSbom.java
+++ b/src/main/java/com/redhat/exhort/sbom/CycloneDXSbom.java
@@ -18,9 +18,11 @@ package com.redhat.exhort.sbom;
 import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.github.packageurl.MalformedPackageURLException;
+import com.redhat.exhort.logging.LoggersFactory;
 import org.cyclonedx.BomGeneratorFactory;
 import org.cyclonedx.CycloneDxSchema.Version;
 import org.cyclonedx.model.Bom;
@@ -35,7 +37,7 @@ import static com.redhat.exhort.impl.ExhortApi.debugLoggingIsNeeded;
 
 public class CycloneDXSbom implements Sbom {
 
-  private System.Logger log = System.getLogger(this.getClass().getName());
+  private Logger log = LoggersFactory.getLogger(this.getClass().getName());
   private static final Version VERSION = Version.VERSION_14;
   private String exhortIgnoreMethod;
   private Bom bom;
@@ -248,7 +250,7 @@ public class CycloneDXSbom implements Sbom {
       String jsonString = BomGeneratorFactory.createJson(VERSION, bom).toJsonString();
       if(debugLoggingIsNeeded())
       {
-        log.log(System.Logger.Level.INFO,jsonString);
+        log.info("Generated Sbom Json:" + System.lineSeparator() + jsonString);
       }
       return jsonString;
     }

--- a/src/main/java/com/redhat/exhort/utils/PythonControllerBase.java
+++ b/src/main/java/com/redhat/exhort/utils/PythonControllerBase.java
@@ -18,6 +18,7 @@ package com.redhat.exhort.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.exhort.exception.PackageNotInstalledException;
+import com.redhat.exhort.logging.LoggersFactory;
 import com.redhat.exhort.tools.Operations;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -75,7 +77,7 @@ public abstract class PythonControllerBase {
   }
 
 
-  private System.Logger log = System.getLogger(this.getClass().getName());
+  private Logger log = LoggersFactory.getLogger(this.getClass().getName());
   protected Path pythonEnvironmentDir;
   protected Path pipBinaryDir;
 
@@ -244,15 +246,15 @@ public abstract class PythonControllerBase {
     String freeze = getPipFreezeFromEnvironment();
     String freezeMessage = "";
     if(debugLoggingIsNeeded()) {
-      freezeMessage = String.format("pip freeze --all command result -> %s %s", System.lineSeparator(), freeze);
-      log.log(System.Logger.Level.INFO, freezeMessage);
+      freezeMessage = String.format("Package Manager PIP freeze --all command result output -> %s %s", System.lineSeparator(), freeze);
+      log.info(freezeMessage);
     }
     String[] deps = freeze.split(System.lineSeparator());
     String depNames = Arrays.stream(deps).map(PythonControllerBase::getDependencyName).collect(Collectors.joining(" "));
     String pipShowOutput = getPipShowFromEnvironment(depNames);
     if(debugLoggingIsNeeded()) {
-      String pipShowMessage = String.format("pip show command result -> %s %s", System.lineSeparator(), pipShowOutput);
-      log.log(System.Logger.Level.INFO, pipShowMessage);
+      String pipShowMessage = String.format("Package Manager PIP show command result output -> %s %s", System.lineSeparator(), pipShowOutput);
+      log.info(pipShowMessage);
     }
     List<String> allPipShowLines = splitPipShowLines(pipShowOutput);
     boolean matchManifestVersions = getBooleanValueEnvironment("MATCH_MANIFEST_VERSIONS", "true");


### PR DESCRIPTION
## Description

### Why it needed

When EXHORT_DEBUG=true , and you are using a plugin that uses this library ( for example Intelli-J RHDA Plugin), then when you opening several supported manifest files concurrently, and exit and re-enter them to check something, you can easily lose yourself among the huge dumps of generated logs from the library, hence we need to associate each request (logs)  invoked by a thread by a unique identifier ( UUID will be enough for this purpose), so it will be attached to every log message.

As a Consequence and because it was needed, i developed also a very simple "Logging Framework" That tailored to the Specific needs of the API, so the process it as follows:
1.For each request, generate an  exhort-client-trace-id UUID value.
2. Transplant the generated exhort-client-trace-id into all log messages of the request by intercepting them before dumping to console.
3. Reformat log messages  in a Json format.
4. If the log message contains a JSON dumped to the console or a Package manager output, then print the message  beautified after the json log message ( in this case, the log json message contains only meta-data fields, including exhort-client-trace-id), otherwise, the message will be part of the json log message as one of the fields.
Example for log message that doesn't contain a json or any Package manager output structure:
```json
{"ex-client-trace-id":"1d99ec14-57a0-4709-b2e0-4620ad8f837d","logLevel":"INFO","logMessage":"Unique Identifier associated with this request ( Received from Exhort Backend ) - ex-request-id= : 79b830116732bbfa8e645337e3e76feae1df5959695707b7a3036d494c292e98","methodName":"com.redhat.exhort.impl.ExhortApi lambda$logExhortRequestId$5","loggerName":"com.redhat.exhort.impl.ExhortApi","timestamp":"2024-02-08T15:13:19.452316841+02:00[Asia/Jerusalem]"}
```

Example For log message that contains a json structure:
```json
{"ex-client-trace-id":"1d99ec14-57a0-4709-b2e0-4620ad8f837d","logLevel":"INFO","logMessage":"log Message Contains a structure , and it will follow after the log entry","methodName":"com.redhat.exhort.impl.ExhortApi getAnalysisReportFromResponse","loggerName":"com.redhat.exhort.impl.ExhortApi","timestamp":"2024-02-08T12:21:14.039766416+02:00[Asia/Jerusalem]"}
Response body received from exhort server : 
 {
  "scanned" : {
    "total" : 0,
    "direct" : 0,
    "transitive" : 0
  },
  "providers" : {
    "trusted-content" : {
      "status" : {
        "ok" : true,
        "name" : "trusted-content",
        "code" : 200,
        "message" : "OK"
      }
    },
    "osv-nvd" : {
      "status" : {
        "ok" : true,
        "name" : "osv-nvd",
        "code" : 200,
        "message" : "OK"
      }
    },
    "snyk" : {
      "status" : {
        "ok" : true,
        "name" : "snyk",
        "code" : 200,
        "message" : "OK"
      }
    }
  }
}
```

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.


