### PR TITLE
fix: npm - cannot find the generated package-lock.json

### DIFF
--- a/src/main/java/com/redhat/exhort/impl/ExhortApi.java
+++ b/src/main/java/com/redhat/exhort/impl/ExhortApi.java
@@ -75,7 +75,7 @@ public final class ExhortApi implements Api {
   public static final void main(String[] args) throws IOException, InterruptedException, ExecutionException {
     System.setProperty("EXHORT_DEV_MODE", "true");
     AnalysisReport analysisReport = new ExhortApi()
-      .stackAnalysis("/home/zgrinber/git/exhort-java-api/src/test/resources/tst_manifests/maven/deps_with_ignore_on_artifact/pom.xml").get();
+      .stackAnalysisMixed("/home/zgrinber/.jenkins/workspace/run RHDA Analysis/package.json").get().json;
 //    ObjectMapper om = new ObjectMapper().configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
 //    System.out.println(om.writerWithDefaultPrettyPrinter().writeValueAsString(analysisReport));
 //    AnalysisReport analysisReport = new ExhortApi()
@@ -170,8 +170,8 @@ public final class ExhortApi implements Api {
 
   private String commonHookBeginning(boolean startOfApi) {
     if(startOfApi) {
-      LOG.info("Start of exhort-java-api client");
       generateClientRequestId();
+      LOG.info("Start of exhort-java-api client");
     }
     else {
       if(Objects.isNull(getClientRequestId())) {

--- a/src/main/java/com/redhat/exhort/providers/JavaScriptNpmProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptNpmProvider.java
@@ -139,17 +139,25 @@ public final class JavaScriptNpmProvider extends Provider {
         manifestPath.getParent().toString() };
     // execute the clean command
     Operations.runProcess(createPackageLock, npmEnvs);
+    String[] npmAllDeps;
+    Path workDir=null;
+    if(!manifestPath.getParent().toString().trim().contains(" ")) {
 
-
-    var npmAllDeps = new String[] { npm, "ls", includeTransitive ? "--all" : "", "--omit=dev", "--package-lock-only",
-        "--json", "--prefix", manifestPath.getParent().toString() };
+      npmAllDeps = new String[]{npm, "ls", includeTransitive ? "--all" : "", "--omit=dev", "--package-lock-only",
+        "--json", "--prefix", manifestPath.getParent().toString()};
+    }
+    else {
+      npmAllDeps = new String[]{npm, "ls", includeTransitive ? "--all" : "", "--omit=dev", "--package-lock-only",
+        "--json"};
+      workDir = manifestPath.getParent();
+    }
     // execute the clean command
     String npmOutput;
     if (npmEnvs != null) {
-      npmOutput = Operations.runProcessGetOutput(null, npmAllDeps,
+      npmOutput = Operations.runProcessGetOutput(workDir, npmAllDeps,
         npmEnvs.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).toArray(String[]::new));
     } else {
-      npmOutput = Operations.runProcessGetOutput(null, npmAllDeps);
+      npmOutput = Operations.runProcessGetOutput(workDir, npmAllDeps);
     }
     if(debugLoggingIsNeeded()) {
       log.log(System.Logger.Level.INFO,String.format("Npm Listed Install Pacakges in Json : %s %s",System.lineSeparator(),npmOutput));


### PR DESCRIPTION
## Description

in case directory has spaces, need to invoke npm ls command from that directory , without prefix flag, this change fixes an error of not finding the package-lock.json in a directory that contains spaces


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

