### PR TITLE
fix: js related binaries

### DIFF
--- a/src/main/java/com/redhat/exhort/providers/JavaScriptNpmProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptNpmProvider.java
@@ -16,6 +16,7 @@
 package com.redhat.exhort.providers;
 
 import com.redhat.exhort.tools.Ecosystem;
+import com.redhat.exhort.tools.Operations;
 import java.nio.file.Path;
 
 /**
@@ -25,7 +26,7 @@ import java.nio.file.Path;
 public final class JavaScriptNpmProvider extends JavaScriptProvider {
 
   public static final String LOCK_FILE = "package-lock.json";
-  public static final String CMD_NAME = "npm";
+  public static final String CMD_NAME = Operations.isWindows() ? "npm.cmd" : "npm";
 
   public JavaScriptNpmProvider(Path manifest) {
     super(manifest, Ecosystem.Type.NPM, CMD_NAME);

--- a/src/main/java/com/redhat/exhort/providers/JavaScriptPnpmProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptPnpmProvider.java
@@ -18,6 +18,7 @@ package com.redhat.exhort.providers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.exhort.tools.Ecosystem;
+import com.redhat.exhort.tools.Operations;
 import java.nio.file.Path;
 
 /**
@@ -27,7 +28,7 @@ import java.nio.file.Path;
 public final class JavaScriptPnpmProvider extends JavaScriptProvider {
 
   public static final String LOCK_FILE = "pnpm-lock.yaml";
-  public static final String CMD_NAME = "pnpm";
+  public static final String CMD_NAME = Operations.isWindows() ? "pnpm.cmd" : "pnpm";
 
   public JavaScriptPnpmProvider(Path manifest) {
     super(manifest, Ecosystem.Type.PNPM, CMD_NAME);

--- a/src/main/java/com/redhat/exhort/providers/JavaScriptYarnProvider.java
+++ b/src/main/java/com/redhat/exhort/providers/JavaScriptYarnProvider.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 public final class JavaScriptYarnProvider extends JavaScriptProvider {
 
   public static final String LOCK_FILE = "yarn.lock";
-  public static final String CMD_NAME = "yarn";
+  public static final String CMD_NAME = Operations.isWindows() ? "yarn.cmd" : "yarn";
 
   private static final Pattern versionPattern = Pattern.compile("^([0-9]+)\\.");
 


### PR DESCRIPTION
## Description

Use the `.cmd` suffix for JS related package managers when running on Windows
**Related issue (if any):** fixes #160 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
