### PR TITLE
fix: correct go path for commands executed in method getFinalPackagesVersionsForModule

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
@@ -318,9 +318,9 @@ public final class GoModulesProvider extends Provider {
 
   private Map<String, List<String>> getFinalPackagesVersionsForModule(
       Map<String, List<String>> edges, Path manifestPath) {
-    Operations.runProcessGetOutput(manifestPath.getParent(), "go", "mod", "download");
+    Operations.runProcessGetOutput(manifestPath.getParent(), goExecutable, "mod", "download");
     String finalVersionsForAllModules =
-        Operations.runProcessGetOutput(manifestPath.getParent(), "go", "list", "-m", "all");
+        Operations.runProcessGetOutput(manifestPath.getParent(), goExecutable, "list", "-m", "all");
     Map<String, String> finalModulesVersions =
         Arrays.stream(finalVersionsForAllModules.split(Operations.GENERIC_LINE_SEPARATOR))
             .filter(string -> string.trim().split(" ").length == 2)
@@ -395,8 +395,7 @@ public final class GoModulesProvider extends Provider {
   }
 
   private String buildGoModulesDependencies(Path manifestPath) {
-    String[] goModulesDeps;
-    goModulesDeps = new String[] {goExecutable, "mod", "graph"};
+    String[] goModulesDeps = new String[] {goExecutable, "mod", "graph"};
 
     // execute the clean command
     String goModulesOutput =


### PR DESCRIPTION
## Description

fix: correct go path for commands executed in method getFinalPackagesVersionsForModule

This happens because [`getFinalPackagesVersionsForModule`](https://github.com/guacsec/trustify-da-java-client/blob/v0.0.10/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java#L319-L323) doesn't use the resolved go executable path.

This is uncovered by https://github.com/guacsec/trustify-da-java-client/pull/188 which set the use of the MVS algorithm default to true and trigger the  `getFinalPackagesVersionsForModule` method by default.

**Related issue (if any):** fixes https://github.com/guacsec/trustify-da-java-client/issues/224

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.