### PR TITLE
fix: java stack analysis doesn't ignore deps inherited version

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/sbom/Sbom.java
+++ b/src/main/java/io/github/guacsec/trustifyda/sbom/Sbom.java
@@ -33,6 +33,8 @@ public interface Sbom {
 
   public void setBelongingCriteriaBinaryAlgorithm(BelongingCondition belongingCondition);
 
+  public void setCoordinateBasedMatching();
+
   public boolean checkIfPackageInsideDependsOnList(PackageURL component, String name);
 
   void removeRootComponent();


### PR DESCRIPTION
fix: java stack analysis doesn'tt ignore deps inherited version

@ruromero could you review this?  This follows the same approach implemented in https://github.com/guacsec/trustify-da-javascript-client/pull/219 Thanks.

fixes: https://github.com/guacsec/trustify-da-java-client/issues/233

https://issues.redhat.com/browse/TC-3352

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.