### PR TITLE
fix: fix parsing with indented comments in requirements.txt

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/utils/PythonControllerBase.java
+++ b/src/main/java/io/github/guacsec/trustifyda/utils/PythonControllerBase.java
@@ -153,7 +153,7 @@ public abstract class PythonControllerBase {
     try {
       linesOfRequirements =
           Files.readAllLines(requirementsPath).stream()
-              .filter((line) -> !line.startsWith("#"))
+              .filter((line) -> !line.trim().startsWith("#") && !line.trim().isEmpty())
               .map(String::trim)
               .collect(Collectors.toList());
     } catch (IOException e) {


### PR DESCRIPTION
## Description

fix: fix parsing with indented comments in requirements.txt

fixes: https://github.com/guacsec/trustify-da-java-client/issues/235

https://issues.redhat.com/browse/TC-3360

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.