### PR TITLE
fix: add missing environment variable to test

### DIFF
--- a/src/test/java/io/github/guacsec/trustifyda/providers/Python_Provider_Test.java
+++ b/src/test/java/io/github/guacsec/trustifyda/providers/Python_Provider_Test.java
@@ -85,6 +85,8 @@ class Python_Provider_Test extends ExhortTest {
   }
 
   @EnabledIfEnvironmentVariable(named = "RUN_PYTHON_BIN", matches = "true")
+  @SetSystemProperty(key = PythonControllerBase.PROP_TRUSTIFY_DA_PYTHON_VIRTUAL_ENV, value = "true")
+  @RestoreSystemProperties
   @ParameterizedTest
   @MethodSource("testFolders")
   void test_the_provideComponent(String testFolder) throws IOException {


### PR DESCRIPTION
### **User description**
Add missing environment variable to Python_Provider_Test. 

CI fails when PR is triggered by `pr.yml` file where retrieves env var like `RUN_PYTHON_BIN: ${{ vars.RUN_PYTHON_BIN }}` since the repo variable defines `true` for `RUN_PYTHON_BIN`

```
 Error:  Errors: 
Error:    Python_Provider_Test.test_the_provideComponent:105 » PackageNotInstalled Package name=>anyio is not installed on your python environment, either install it ( better to install requirements.txt altogether) or turn on environment variable TRUSTIFY_DA_PYTHON_VIRTUAL_ENV=true to automatically install it on virtual environment (will slow down the analysis)
Error:    Python_Provider_Test.test_the_provideComponent:105 » PackageNotInstalled Package name=>anyio is not installed on your python environment, either install it ( better to install requirements.txt altogether) or turn on environment variable TRUSTIFY_DA_PYTHON_VIRTUAL_ENV=true to automatically install it on virtual environment (will slow down the analysis)
```


___

### **PR Type**
Tests


___

### **Description**
- Replace environment variable check with system property annotation

- Use PythonControllerBase.PROP_TRUSTIFY_DA_PYTHON_VIRTUAL_ENV property

- Add @RestoreSystemProperties to restore state after test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["@EnabledIfEnvironmentVariable<br/>RUN_PYTHON_BIN"] -- "replaced by" --> B["@SetSystemProperty<br/>PROP_TRUSTIFY_DA_PYTHON_VIRTUAL_ENV"]
  B --> C["@RestoreSystemProperties"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Python_Provider_Test.java</strong><dd><code>Replace environment variable with system property annotations</code></dd></summary>
<hr>

src/test/java/io/github/guacsec/trustifyda/providers/Python_Provider_Test.java

<ul><li>Replaced @EnabledIfEnvironmentVariable annotation with <br>@SetSystemProperty<br> <li> Changed from checking RUN_PYTHON_BIN environment variable to setting <br>system property<br> <li> Added @RestoreSystemProperties annotation to clean up system <br>properties after test<br> <li> Uses PythonControllerBase.PROP_TRUSTIFY_DA_PYTHON_VIRTUAL_ENV constant <br>for property key</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-da-java-client/pull/274/files#diff-95eb8b7be112980686622a8271135886e37490a47a637ec8930b8742b2e37554">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

