### PR TITLE
build: bump com.diffplug.spotless:spotless-maven-plugin from 2.44.4 to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <pitest-junit5-plugin.version>1.1.2</pitest-junit5-plugin.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
     <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
-    <spotless-maven-plugin.version>2.44.4</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
   </properties>
 

--- a/src/test/java/io/github/guacsec/trustifyda/providers/CargoProviderCargoParsingTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/providers/CargoProviderCargoParsingTest.java
@@ -538,7 +538,7 @@ public class CargoProviderCargoParsingTest {
     }
 
     contentBuilder.append(
-        """
+"""
 
 [workspace.dependencies]
 """);


### PR DESCRIPTION
## Description

build: bump com.diffplug.spotless:spotless-maven-plugin from 2.44.4 to 3.2.1
replace https://github.com/guacsec/trustify-da-java-client/pull/278
