### PR TITLE
fix(deps): remove dependabot ecosystems for test-only fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,30 +6,6 @@ updates:
       interval: "daily"
     exclude-paths:
       - "src/test/**"
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    exclude-paths:
-      - "src/test/**"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    exclude-paths:
-      - "src/test/**"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    exclude-paths:
-      - "src/test/**"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    exclude-paths:
-      - "src/test/**"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
fix(deps): remove dependabot ecosystems for test-only fixtures

Removes gradle, npm, pip, and gomod package ecosystems that only scan test fixtures where exclude-paths isn't working, preventing unwanted PRs like https://github.com/guacsec/trustify-da-java-client/pull/335 for non-project dependencies.
