### PR TITLE
build: bump trustify-da-api-model to 2.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
     <!-- Dependencies -->
-    <trustify-da-api-model.version>2.0.4</trustify-da-api-model.version>
+    <trustify-da-api-model.version>2.0.7</trustify-da-api-model.version>
     <jackson.version>2.21.1</jackson.version>
     <jackson-annotations.version>2.21</jackson-annotations.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
build: bump trustify-da-api-model to 2.0.7

replace https://github.com/guacsec/trustify-da-java-client/pull/333. 

I can't get a meaningful CI result from https://github.com/guacsec/trustify-da-java-client/pull/333, although it was rebased to latest `main`

Hi @ruromero, could you approve this one? 