### PR TITLE
chore: exclude test fixture manifests from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,41 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  # Prevent Dependabot from scanning test fixture manifests.
+  # These contain intentionally pinned (and sometimes vulnerable)
+  # dependencies used as test data for the dependency-analysis client.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "src/test/**"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "src/test/**"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "src/test/**"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "src/test/**"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "src/test/**"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

- Add Dependabot ecosystem entries for npm, pip, gomod, gradle, and cargo with `exclude-paths: ["src/test/**"]` and `open-pull-requests-limit: 0`
- Prevents Dependabot from raising version update PRs for test fixture manifests in `src/test/resources/tst_manifests/`
- These manifests contain intentionally pinned (and sometimes vulnerable) dependencies used as test data for the dependency-analysis client

**Note:** `exclude-paths` only applies to Dependabot version updates. Security update PRs for test fixtures (e.g. #403, #404, #405, #407) must be closed manually and their alerts dismissed.

## Test plan

- [x] Verify `dependabot.yml` is valid YAML
- [ ] After merge, verify no new Dependabot version update PRs are created for `src/test/` manifests
- [ ] Close existing test fixture security update PRs (#403, #404, #405, #407) and dismiss their alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)