### PR TITLE
fix(go): merge children on MVS version key collision instead of overwriting

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
@@ -354,7 +354,14 @@ public final class GoModulesProvider extends Provider {
           }
           List<String> packagesWithFinalVersions =
               getListOfPackagesWithFinalVersions(finalModulesVersions, value);
-          listWithModifiedVersions.put(packageWithSelectedVersion, packagesWithFinalVersions);
+          listWithModifiedVersions.merge(
+              packageWithSelectedVersion,
+              packagesWithFinalVersions,
+              (existing, incoming) -> {
+                var combined = new java.util.LinkedHashSet<>(existing);
+                combined.addAll(incoming);
+                return new ArrayList<>(combined);
+              });
         });
 
     return listWithModifiedVersions;

--- a/src/test/java/io/github/guacsec/trustifyda/providers/Golang_Modules_Provider_Test.java
+++ b/src/test/java/io/github/guacsec/trustifyda/providers/Golang_Modules_Provider_Test.java
@@ -198,6 +198,40 @@ class Golang_Modules_Provider_Test extends ExhortTest {
             == 1);
   }
 
+  /**
+   * Verifies that MVS-enabled mode preserves all transitive dependencies (TC-3818).
+   *
+   * <p>When MVS is enabled (the default), {@code getFinalPackagesVersionsForModule()} uses {@code
+   * HashMap.put()} which overwrites children when two original parent versions remap to the same
+   * MVS-selected version. This causes the Java client to produce fewer components than the JS
+   * client.
+   *
+   * <p>The JS client produces 138 components for this fixture. This test is expected to FAIL until
+   * the HashMap.put() collision bug is fixed.
+   */
+  @Test
+  void Test_Golang_MvS_Enabled_Preserves_All_Transitive_Dependencies() throws IOException {
+    // Given the MVS test fixture with MVS enabled (the default — no property override)
+    String goModPath = getFileFromResource("go.mod", "msc/golang/mvs_logic/go.mod");
+    Path manifest = Path.of(goModPath);
+    GoModulesProvider goModulesProvider = new GoModulesProvider(manifest);
+
+    // When generating the SBOM with stack analysis
+    String resultSbom =
+        dropIgnoredKeepFormat(
+            goModulesProvider.getDependenciesSbom(manifest, true).getAsJsonString());
+
+    // Then the SBOM should contain exactly 138 components (matching JS client output)
+    JsonNode sbomTree = JSON_MAPPER.readTree(resultSbom);
+    int componentCount = sbomTree.path("components").size();
+    assertEquals(
+        138,
+        componentCount,
+        "MVS-enabled SBOM should contain 138 components (matching JS client). "
+            + "A lower count indicates the HashMap.put() collision bug in "
+            + "getFinalPackagesVersionsForModule() is losing transitive dependencies.");
+  }
+
   @Test
   void test_isGoToolchainEntry_filters_go_and_toolchain() {
     // go@* entries should be filtered

--- a/src/test/java/io/github/guacsec/trustifyda/providers/Golang_Modules_Provider_Test.java
+++ b/src/test/java/io/github/guacsec/trustifyda/providers/Golang_Modules_Provider_Test.java
@@ -205,9 +205,6 @@ class Golang_Modules_Provider_Test extends ExhortTest {
    * HashMap.put()} which overwrites children when two original parent versions remap to the same
    * MVS-selected version. This causes the Java client to produce fewer components than the JS
    * client.
-   *
-   * <p>The JS client produces 138 components for this fixture. This test is expected to FAIL until
-   * the HashMap.put() collision bug is fixed.
    */
   @Test
   void Test_Golang_MvS_Enabled_Preserves_All_Transitive_Dependencies() throws IOException {

--- a/src/test/resources/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
@@ -1,531 +1,390 @@
 {
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "pkg:golang/golang.org/x/example@v0.0.0",
-      "group": "golang.org/x",
-      "name": "example",
-      "version": "v0.0.0",
-      "purl": "pkg:golang/golang.org/x/example@v0.0.0"
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:golang/golang.org/x/example@v0.0.0",
+      "group" : "golang.org/x",
+      "name" : "example",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/golang.org/x/example@v0.0.0"
     }
   },
-  "components": [
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/viper@v1.3.2",
-      "group": "github.com/spf13",
-      "name": "viper",
-      "version": "v1.3.2",
-      "purl": "pkg:golang/github.com/spf13/viper@v1.3.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
-      "group": "github.com/armon",
-      "name": "consul-api",
-      "version": "v0.0.0-20180202201655-eb2c6b5be1b6",
-      "purl": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
-      "group": "github.com/coreos",
-      "name": "etcd",
-      "version": "v3.3.10+incompatible",
-      "purl": "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
-      "group": "github.com/coreos",
-      "name": "go-etcd",
-      "version": "v2.0.0+incompatible",
-      "purl": "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
-      "group": "github.com/coreos",
-      "name": "go-semver",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/coreos/go-semver@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-      "group": "github.com/fsnotify",
-      "name": "fsnotify",
-      "version": "v1.4.7",
-      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
-      "group": "github.com/hashicorp",
-      "name": "hcl",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/hashicorp/hcl@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/magiconair/properties@v1.8.0",
-      "group": "github.com/magiconair",
-      "name": "properties",
-      "version": "v1.8.0",
-      "purl": "pkg:golang/github.com/magiconair/properties@v1.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-      "group": "github.com/mitchellh",
-      "name": "mapstructure",
-      "version": "v1.1.2",
-      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
-      "group": "github.com/pelletier",
-      "name": "go-toml",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/pelletier/go-toml@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/afero@v1.1.2",
-      "group": "github.com/spf13",
-      "name": "afero",
-      "version": "v1.1.2",
-      "purl": "pkg:golang/github.com/spf13/afero@v1.1.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/cast@v1.3.0",
-      "group": "github.com/spf13",
-      "name": "cast",
-      "version": "v1.3.0",
-      "purl": "pkg:golang/github.com/spf13/cast@v1.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
-      "group": "github.com/spf13",
-      "name": "jwalterweatherman",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.3",
-      "group": "github.com/spf13",
-      "name": "pflag",
-      "version": "v1.0.3",
-      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.2.2",
-      "group": "github.com/stretchr",
-      "name": "testify",
-      "version": "v1.2.2",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.2.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
-      "group": "github.com/ugorji/go",
-      "name": "codec",
-      "version": "v0.0.0-20181204163529-d75b2dcb6bc8",
-      "purl": "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
-      "group": "github.com/xordataexchange",
-      "name": "crypt",
-      "version": "v0.0.3-0.20170626215501-b2862e3d0a77",
-      "purl": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-      "group": "golang.org/x",
-      "name": "crypto",
-      "version": "v0.0.0-20200622213623-75b288015ac9",
-      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-      "group": "golang.org/x",
-      "name": "sys",
-      "version": "v0.0.0-20200930185726-fdedc70b468f",
-      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.3",
-      "group": "golang.org/x",
-      "name": "text",
-      "version": "v0.3.3",
-      "purl": "pkg:golang/golang.org/x/text@v0.3.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
-      "group": "gopkg.in",
-      "name": "yaml.v2",
-      "version": "v2.2.2",
-      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-      "group": "golang.org/x",
-      "name": "net",
-      "version": "v0.0.0-20201021035429-f5854403a974",
-      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/cobra@v0.0.5",
-      "group": "github.com/spf13",
-      "name": "cobra",
-      "version": "v0.0.5",
-      "purl": "pkg:golang/github.com/spf13/cobra@v0.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-      "group": "github.com/burntsushi",
-      "name": "toml",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/burntsushi/toml@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
-      "group": "github.com/cpuguy83",
-      "name": "go-md2man",
-      "version": "v1.0.10",
-      "purl": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
-      "group": "github.com/inconshreveable",
-      "name": "mousetrap",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
-      "group": "github.com/mitchellh",
-      "name": "go-homedir",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "group": "github.com/davecgh",
-      "name": "go-spew",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "group": "github.com/pmezard",
-      "name": "go-difflib",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
-      "group": "golang.org/x",
-      "name": "tools",
-      "version": "v0.0.0-20210112183307-1e6ecd4bf1b0",
-      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "group": "gopkg.in",
-      "name": "yaml.v3",
-      "version": "v3.0.1",
-      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-      "group": "gopkg.in",
-      "name": "check.v1",
-      "version": "v0.0.0-20161208181325-20d25e280405",
-      "purl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-      "group": "github.com/yuin",
-      "name": "goldmark",
-      "version": "v1.2.1",
-      "purl": "pkg:golang/github.com/yuin/goldmark@v1.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mod@v0.3.0",
-      "group": "golang.org/x",
-      "name": "mod",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/golang.org/x/mod@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-      "group": "golang.org/x",
-      "name": "sync",
-      "version": "v0.0.0-20201020160332-67f06af15bc9",
-      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "group": "golang.org/x",
-      "name": "xerrors",
-      "version": "v0.0.0-20200804184101-5ec99f83aff1",
-      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
-      "group": "github.com/russross",
-      "name": "blackfriday",
-      "version": "v1.5.2",
-      "purl": "pkg:golang/github.com/russross/blackfriday@v1.5.2"
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "pkg:golang/golang.org/x/example@v0.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/spf13/cobra@v0.0.5",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/viper@v1.3.2",
-      "dependsOn": [
-        "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
-        "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
-        "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
-        "pkg:golang/github.com/coreos/go-semver@v0.2.0",
-        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-        "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
-        "pkg:golang/github.com/magiconair/properties@v1.8.0",
-        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-        "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
-        "pkg:golang/github.com/spf13/afero@v1.1.2",
-        "pkg:golang/github.com/spf13/cast@v1.3.0",
-        "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.3",
-        "pkg:golang/github.com/stretchr/testify@v1.2.2",
-        "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
-        "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-        "pkg:golang/golang.org/x/text@v0.3.3",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/magiconair/properties@v1.8.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/afero@v1.1.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/cast@v1.3.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/stretchr/testify@v1.2.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.3",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.2.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/text@v0.3.3",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/cobra@v0.0.5",
-      "dependsOn": [
-        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-        "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
-        "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
-        "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.3",
-        "pkg:golang/github.com/spf13/viper@v1.3.2",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
-      "dependsOn": [
-        "pkg:golang/github.com/russross/blackfriday@v1.5.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
-      "dependsOn": [
-        "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-        "pkg:golang/golang.org/x/mod@v0.3.0",
-        "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mod@v0.3.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
-      "dependsOn": []
-    }
-  ]
+  "components" : [ {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/viper@v1.3.2",
+    "group" : "github.com/spf13",
+    "name" : "viper",
+    "version" : "v1.3.2",
+    "purl" : "pkg:golang/github.com/spf13/viper@v1.3.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+    "group" : "github.com/armon",
+    "name" : "consul-api",
+    "version" : "v0.0.0-20180202201655-eb2c6b5be1b6",
+    "purl" : "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
+    "group" : "github.com/coreos",
+    "name" : "etcd",
+    "version" : "v3.3.10+incompatible",
+    "purl" : "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
+    "group" : "github.com/coreos",
+    "name" : "go-etcd",
+    "version" : "v2.0.0+incompatible",
+    "purl" : "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+    "group" : "github.com/coreos",
+    "name" : "go-semver",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/coreos/go-semver@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+    "group" : "github.com/fsnotify",
+    "name" : "fsnotify",
+    "version" : "v1.4.7",
+    "purl" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+    "group" : "github.com/hashicorp",
+    "name" : "hcl",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/hashicorp/hcl@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/magiconair/properties@v1.8.0",
+    "group" : "github.com/magiconair",
+    "name" : "properties",
+    "version" : "v1.8.0",
+    "purl" : "pkg:golang/github.com/magiconair/properties@v1.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+    "group" : "github.com/mitchellh",
+    "name" : "mapstructure",
+    "version" : "v1.1.2",
+    "purl" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+    "group" : "github.com/pelletier",
+    "name" : "go-toml",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/pelletier/go-toml@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/afero@v1.1.2",
+    "group" : "github.com/spf13",
+    "name" : "afero",
+    "version" : "v1.1.2",
+    "purl" : "pkg:golang/github.com/spf13/afero@v1.1.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/cast@v1.3.0",
+    "group" : "github.com/spf13",
+    "name" : "cast",
+    "version" : "v1.3.0",
+    "purl" : "pkg:golang/github.com/spf13/cast@v1.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+    "group" : "github.com/spf13",
+    "name" : "jwalterweatherman",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/pflag@v1.0.3",
+    "group" : "github.com/spf13",
+    "name" : "pflag",
+    "version" : "v1.0.3",
+    "purl" : "pkg:golang/github.com/spf13/pflag@v1.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.2.2",
+    "group" : "github.com/stretchr",
+    "name" : "testify",
+    "version" : "v1.2.2",
+    "purl" : "pkg:golang/github.com/stretchr/testify@v1.2.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
+    "group" : "github.com/ugorji/go",
+    "name" : "codec",
+    "version" : "v0.0.0-20181204163529-d75b2dcb6bc8",
+    "purl" : "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+    "group" : "github.com/xordataexchange",
+    "name" : "crypt",
+    "version" : "v0.0.3-0.20170626215501-b2862e3d0a77",
+    "purl" : "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+    "group" : "golang.org/x",
+    "name" : "crypto",
+    "version" : "v0.0.0-20200622213623-75b288015ac9",
+    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+    "group" : "golang.org/x",
+    "name" : "sys",
+    "version" : "v0.0.0-20200930185726-fdedc70b468f",
+    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.3",
+    "group" : "golang.org/x",
+    "name" : "text",
+    "version" : "v0.3.3",
+    "purl" : "pkg:golang/golang.org/x/text@v0.3.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+    "group" : "gopkg.in",
+    "name" : "yaml.v2",
+    "version" : "v2.2.2",
+    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
+    "group" : "golang.org/x",
+    "name" : "net",
+    "version" : "v0.0.0-20201021035429-f5854403a974",
+    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "group" : "github.com/davecgh",
+    "name" : "go-spew",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "group" : "github.com/pmezard",
+    "name" : "go-difflib",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/cobra@v0.0.5",
+    "group" : "github.com/spf13",
+    "name" : "cobra",
+    "version" : "v0.0.5",
+    "purl" : "pkg:golang/github.com/spf13/cobra@v0.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+    "group" : "github.com/burntsushi",
+    "name" : "toml",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/burntsushi/toml@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+    "group" : "github.com/cpuguy83",
+    "name" : "go-md2man",
+    "version" : "v1.0.10",
+    "purl" : "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+    "group" : "github.com/inconshreveable",
+    "name" : "mousetrap",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+    "group" : "github.com/mitchellh",
+    "name" : "go-homedir",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+    "group" : "golang.org/x",
+    "name" : "tools",
+    "version" : "v0.0.0-20210112183307-1e6ecd4bf1b0",
+    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+    "group" : "gopkg.in",
+    "name" : "check.v1",
+    "version" : "v0.0.0-20161208181325-20d25e280405",
+    "purl" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+    "group" : "gopkg.in",
+    "name" : "yaml.v3",
+    "version" : "v3.0.1",
+    "purl" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+    "group" : "golang.org/x",
+    "name" : "sync",
+    "version" : "v0.0.0-20201020160332-67f06af15bc9",
+    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "group" : "golang.org/x",
+    "name" : "xerrors",
+    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
+    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+    "group" : "github.com/yuin",
+    "name" : "goldmark",
+    "version" : "v1.2.1",
+    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.3.0",
+    "group" : "golang.org/x",
+    "name" : "mod",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/golang.org/x/mod@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/russross/blackfriday@v1.5.2",
+    "group" : "github.com/russross",
+    "name" : "blackfriday",
+    "version" : "v1.5.2",
+    "purl" : "pkg:golang/github.com/russross/blackfriday@v1.5.2"
+  } ],
+  "dependencies" : [ {
+    "ref" : "pkg:golang/golang.org/x/example@v0.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/spf13/cobra@v0.0.5", "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/viper@v1.3.2",
+    "dependsOn" : [ "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6", "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible", "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible", "pkg:golang/github.com/coreos/go-semver@v0.2.0", "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7", "pkg:golang/github.com/hashicorp/hcl@v1.0.0", "pkg:golang/github.com/magiconair/properties@v1.8.0", "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2", "pkg:golang/github.com/pelletier/go-toml@v1.2.0", "pkg:golang/github.com/spf13/afero@v1.1.2", "pkg:golang/github.com/spf13/cast@v1.3.0", "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0", "pkg:golang/github.com/spf13/pflag@v1.0.3", "pkg:golang/github.com/stretchr/testify@v1.2.2", "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8", "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77", "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/yaml.v2@v2.2.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/magiconair/properties@v1.8.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/afero@v1.1.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/cast@v1.3.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/testify@v1.2.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/pflag@v1.0.3",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/testify@v1.2.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f", "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/text@v0.3.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f" ]
+  }, {
+    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/cobra@v0.0.5",
+    "dependsOn" : [ "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10", "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0", "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0", "pkg:golang/github.com/spf13/pflag@v1.0.3", "pkg:golang/github.com/spf13/viper@v1.3.2", "pkg:golang/gopkg.in/yaml.v2@v2.2.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+    "dependsOn" : [ "pkg:golang/github.com/russross/blackfriday@v1.5.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/github.com/yuin/goldmark@v1.2.1", "pkg:golang/golang.org/x/mod@v0.3.0" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mod@v0.3.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/russross/blackfriday@v1.5.2",
+    "dependsOn" : [ ]
+  } ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
@@ -1,390 +1,531 @@
 {
-  "bomFormat" : "CycloneDX",
-  "specVersion" : "1.4",
-  "version" : 1,
-  "metadata" : {
-    "component" : {
-      "type" : "application",
-      "bom-ref" : "pkg:golang/golang.org/x/example@v0.0.0",
-      "group" : "golang.org/x",
-      "name" : "example",
-      "version" : "v0.0.0",
-      "purl" : "pkg:golang/golang.org/x/example@v0.0.0"
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/golang.org/x/example@v0.0.0",
+      "group": "golang.org/x",
+      "name": "example",
+      "version": "v0.0.0",
+      "purl": "pkg:golang/golang.org/x/example@v0.0.0"
     }
   },
-  "components" : [ {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/viper@v1.3.2",
-    "group" : "github.com/spf13",
-    "name" : "viper",
-    "version" : "v1.3.2",
-    "purl" : "pkg:golang/github.com/spf13/viper@v1.3.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
-    "group" : "github.com/armon",
-    "name" : "consul-api",
-    "version" : "v0.0.0-20180202201655-eb2c6b5be1b6",
-    "purl" : "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
-    "group" : "github.com/coreos",
-    "name" : "etcd",
-    "version" : "v3.3.10+incompatible",
-    "purl" : "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
-    "group" : "github.com/coreos",
-    "name" : "go-etcd",
-    "version" : "v2.0.0+incompatible",
-    "purl" : "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/coreos/go-semver@v0.2.0",
-    "group" : "github.com/coreos",
-    "name" : "go-semver",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/coreos/go-semver@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-    "group" : "github.com/fsnotify",
-    "name" : "fsnotify",
-    "version" : "v1.4.7",
-    "purl" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
-    "group" : "github.com/hashicorp",
-    "name" : "hcl",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/hashicorp/hcl@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/magiconair/properties@v1.8.0",
-    "group" : "github.com/magiconair",
-    "name" : "properties",
-    "version" : "v1.8.0",
-    "purl" : "pkg:golang/github.com/magiconair/properties@v1.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-    "group" : "github.com/mitchellh",
-    "name" : "mapstructure",
-    "version" : "v1.1.2",
-    "purl" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
-    "group" : "github.com/pelletier",
-    "name" : "go-toml",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/pelletier/go-toml@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/afero@v1.1.2",
-    "group" : "github.com/spf13",
-    "name" : "afero",
-    "version" : "v1.1.2",
-    "purl" : "pkg:golang/github.com/spf13/afero@v1.1.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/cast@v1.3.0",
-    "group" : "github.com/spf13",
-    "name" : "cast",
-    "version" : "v1.3.0",
-    "purl" : "pkg:golang/github.com/spf13/cast@v1.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
-    "group" : "github.com/spf13",
-    "name" : "jwalterweatherman",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/pflag@v1.0.3",
-    "group" : "github.com/spf13",
-    "name" : "pflag",
-    "version" : "v1.0.3",
-    "purl" : "pkg:golang/github.com/spf13/pflag@v1.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.2.2",
-    "group" : "github.com/stretchr",
-    "name" : "testify",
-    "version" : "v1.2.2",
-    "purl" : "pkg:golang/github.com/stretchr/testify@v1.2.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
-    "group" : "github.com/ugorji/go",
-    "name" : "codec",
-    "version" : "v0.0.0-20181204163529-d75b2dcb6bc8",
-    "purl" : "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
-    "group" : "github.com/xordataexchange",
-    "name" : "crypt",
-    "version" : "v0.0.3-0.20170626215501-b2862e3d0a77",
-    "purl" : "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-    "group" : "golang.org/x",
-    "name" : "crypto",
-    "version" : "v0.0.0-20200622213623-75b288015ac9",
-    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-    "group" : "golang.org/x",
-    "name" : "sys",
-    "version" : "v0.0.0-20200930185726-fdedc70b468f",
-    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.3",
-    "group" : "golang.org/x",
-    "name" : "text",
-    "version" : "v0.3.3",
-    "purl" : "pkg:golang/golang.org/x/text@v0.3.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
-    "group" : "gopkg.in",
-    "name" : "yaml.v2",
-    "version" : "v2.2.2",
-    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-    "group" : "golang.org/x",
-    "name" : "net",
-    "version" : "v0.0.0-20201021035429-f5854403a974",
-    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "group" : "github.com/davecgh",
-    "name" : "go-spew",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "group" : "github.com/pmezard",
-    "name" : "go-difflib",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/cobra@v0.0.5",
-    "group" : "github.com/spf13",
-    "name" : "cobra",
-    "version" : "v0.0.5",
-    "purl" : "pkg:golang/github.com/spf13/cobra@v0.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-    "group" : "github.com/burntsushi",
-    "name" : "toml",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/burntsushi/toml@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
-    "group" : "github.com/cpuguy83",
-    "name" : "go-md2man",
-    "version" : "v1.0.10",
-    "purl" : "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
-    "group" : "github.com/inconshreveable",
-    "name" : "mousetrap",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
-    "group" : "github.com/mitchellh",
-    "name" : "go-homedir",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
-    "group" : "golang.org/x",
-    "name" : "tools",
-    "version" : "v0.0.0-20210112183307-1e6ecd4bf1b0",
-    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-    "group" : "gopkg.in",
-    "name" : "check.v1",
-    "version" : "v0.0.0-20161208181325-20d25e280405",
-    "purl" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-    "group" : "gopkg.in",
-    "name" : "yaml.v3",
-    "version" : "v3.0.1",
-    "purl" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-    "group" : "golang.org/x",
-    "name" : "sync",
-    "version" : "v0.0.0-20201020160332-67f06af15bc9",
-    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "group" : "golang.org/x",
-    "name" : "xerrors",
-    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
-    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-    "group" : "github.com/yuin",
-    "name" : "goldmark",
-    "version" : "v1.2.1",
-    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.3.0",
-    "group" : "golang.org/x",
-    "name" : "mod",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/golang.org/x/mod@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/russross/blackfriday@v1.5.2",
-    "group" : "github.com/russross",
-    "name" : "blackfriday",
-    "version" : "v1.5.2",
-    "purl" : "pkg:golang/github.com/russross/blackfriday@v1.5.2"
-  } ],
-  "dependencies" : [ {
-    "ref" : "pkg:golang/golang.org/x/example@v0.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/spf13/cobra@v0.0.5", "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/viper@v1.3.2",
-    "dependsOn" : [ "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6", "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible", "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible", "pkg:golang/github.com/coreos/go-semver@v0.2.0", "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7", "pkg:golang/github.com/hashicorp/hcl@v1.0.0", "pkg:golang/github.com/magiconair/properties@v1.8.0", "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2", "pkg:golang/github.com/pelletier/go-toml@v1.2.0", "pkg:golang/github.com/spf13/afero@v1.1.2", "pkg:golang/github.com/spf13/cast@v1.3.0", "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0", "pkg:golang/github.com/spf13/pflag@v1.0.3", "pkg:golang/github.com/stretchr/testify@v1.2.2", "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8", "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77", "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/yaml.v2@v2.2.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/coreos/go-semver@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/magiconair/properties@v1.8.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/afero@v1.1.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/cast@v1.3.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/testify@v1.2.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/pflag@v1.0.3",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/testify@v1.2.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f", "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/text@v0.3.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f" ]
-  }, {
-    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/cobra@v0.0.5",
-    "dependsOn" : [ "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10", "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0", "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0", "pkg:golang/github.com/spf13/pflag@v1.0.3", "pkg:golang/github.com/spf13/viper@v1.3.2", "pkg:golang/gopkg.in/yaml.v2@v2.2.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
-    "dependsOn" : [ "pkg:golang/github.com/russross/blackfriday@v1.5.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/github.com/yuin/goldmark@v1.2.1", "pkg:golang/golang.org/x/mod@v0.3.0" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mod@v0.3.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/russross/blackfriday@v1.5.2",
-    "dependsOn" : [ ]
-  } ]
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/viper@v1.3.2",
+      "group": "github.com/spf13",
+      "name": "viper",
+      "version": "v1.3.2",
+      "purl": "pkg:golang/github.com/spf13/viper@v1.3.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+      "group": "github.com/armon",
+      "name": "consul-api",
+      "version": "v0.0.0-20180202201655-eb2c6b5be1b6",
+      "purl": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
+      "group": "github.com/coreos",
+      "name": "etcd",
+      "version": "v3.3.10+incompatible",
+      "purl": "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
+      "group": "github.com/coreos",
+      "name": "go-etcd",
+      "version": "v2.0.0+incompatible",
+      "purl": "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+      "group": "github.com/coreos",
+      "name": "go-semver",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "group": "github.com/fsnotify",
+      "name": "fsnotify",
+      "version": "v1.4.7",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+      "group": "github.com/hashicorp",
+      "name": "hcl",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/hashicorp/hcl@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/magiconair/properties@v1.8.0",
+      "group": "github.com/magiconair",
+      "name": "properties",
+      "version": "v1.8.0",
+      "purl": "pkg:golang/github.com/magiconair/properties@v1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "group": "github.com/mitchellh",
+      "name": "mapstructure",
+      "version": "v1.1.2",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+      "group": "github.com/pelletier",
+      "name": "go-toml",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/pelletier/go-toml@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/afero@v1.1.2",
+      "group": "github.com/spf13",
+      "name": "afero",
+      "version": "v1.1.2",
+      "purl": "pkg:golang/github.com/spf13/afero@v1.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cast@v1.3.0",
+      "group": "github.com/spf13",
+      "name": "cast",
+      "version": "v1.3.0",
+      "purl": "pkg:golang/github.com/spf13/cast@v1.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+      "group": "github.com/spf13",
+      "name": "jwalterweatherman",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.3",
+      "group": "github.com/spf13",
+      "name": "pflag",
+      "version": "v1.0.3",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.2.2",
+      "group": "github.com/stretchr",
+      "name": "testify",
+      "version": "v1.2.2",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.2.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
+      "group": "github.com/ugorji/go",
+      "name": "codec",
+      "version": "v0.0.0-20181204163529-d75b2dcb6bc8",
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+      "group": "github.com/xordataexchange",
+      "name": "crypt",
+      "version": "v0.0.3-0.20170626215501-b2862e3d0a77",
+      "purl": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+      "group": "golang.org/x",
+      "name": "crypto",
+      "version": "v0.0.0-20200622213623-75b288015ac9",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+      "group": "golang.org/x",
+      "name": "sys",
+      "version": "v0.0.0-20200930185726-fdedc70b468f",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.3",
+      "group": "golang.org/x",
+      "name": "text",
+      "version": "v0.3.3",
+      "purl": "pkg:golang/golang.org/x/text@v0.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "version": "v2.2.2",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
+      "group": "golang.org/x",
+      "name": "net",
+      "version": "v0.0.0-20201021035429-f5854403a974",
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "group": "github.com/davecgh",
+      "name": "go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "group": "github.com/pmezard",
+      "name": "go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v0.0.5",
+      "group": "github.com/spf13",
+      "name": "cobra",
+      "version": "v0.0.5",
+      "purl": "pkg:golang/github.com/spf13/cobra@v0.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+      "group": "github.com/burntsushi",
+      "name": "toml",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/burntsushi/toml@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+      "group": "github.com/cpuguy83",
+      "name": "go-md2man",
+      "version": "v1.0.10",
+      "purl": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+      "group": "github.com/inconshreveable",
+      "name": "mousetrap",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+      "group": "github.com/mitchellh",
+      "name": "go-homedir",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+      "group": "golang.org/x",
+      "name": "tools",
+      "version": "v0.0.0-20210112183307-1e6ecd4bf1b0",
+      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "group": "gopkg.in",
+      "name": "check.v1",
+      "version": "v0.0.0-20161208181325-20d25e280405",
+      "purl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "group": "gopkg.in",
+      "name": "yaml.v3",
+      "version": "v3.0.1",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+      "group": "golang.org/x",
+      "name": "sync",
+      "version": "v0.0.0-20201020160332-67f06af15bc9",
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "group": "golang.org/x",
+      "name": "xerrors",
+      "version": "v0.0.0-20200804184101-5ec99f83aff1",
+      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+      "group": "github.com/yuin",
+      "name": "goldmark",
+      "version": "v1.2.1",
+      "purl": "pkg:golang/github.com/yuin/goldmark@v1.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.3.0",
+      "group": "golang.org/x",
+      "name": "mod",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/golang.org/x/mod@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
+      "group": "github.com/russross",
+      "name": "blackfriday",
+      "version": "v1.5.2",
+      "purl": "pkg:golang/github.com/russross/blackfriday@v1.5.2"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/golang.org/x/example@v0.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/spf13/cobra@v0.0.5",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/viper@v1.3.2",
+      "dependsOn": [
+        "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+        "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
+        "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
+        "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+        "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+        "pkg:golang/github.com/magiconair/properties@v1.8.0",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+        "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+        "pkg:golang/github.com/spf13/afero@v1.1.2",
+        "pkg:golang/github.com/spf13/cast@v1.3.0",
+        "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.3",
+        "pkg:golang/github.com/stretchr/testify@v1.2.2",
+        "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
+        "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+        "pkg:golang/golang.org/x/text@v0.3.3",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/armon/consul-api@v0.0.0-20180202201655-eb2c6b5be1b6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/etcd@v3.3.10%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-etcd@v2.0.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/hcl@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/magiconair/properties@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pelletier/go-toml@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/afero@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cast@v1.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/testify@v1.2.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/jwalterweatherman@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+        "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.3.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+        "pkg:golang/golang.org/x/text@v0.3.3",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v0.0.5",
+      "dependsOn": [
+        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+        "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+        "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.3",
+        "pkg:golang/github.com/spf13/viper@v1.3.2",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cpuguy83/go-md2man@v1.0.10",
+      "dependsOn": [
+        "pkg:golang/github.com/russross/blackfriday@v1.5.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+        "pkg:golang/golang.org/x/mod@v0.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.3.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/russross/blackfriday@v1.5.2",
+      "dependsOn": []
+    }
+  ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_no_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_ignore/expected_sbom_stack_analysis.json
@@ -1,2148 +1,1399 @@
 {
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-      "group": "github.com/rhecosystemappeng/saasi",
-      "name": "deployer",
-      "version": "v0.0.0",
-      "purl": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+      "group" : "github.com/rhecosystemappeng/saasi",
+      "name" : "deployer",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
     }
   },
-  "components": [
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-      "group": "github.com/stretchr",
-      "name": "testify",
-      "version": "v1.8.3",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.8.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "group": "github.com/davecgh",
-      "name": "go-spew",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "group": "github.com/pmezard",
-      "name": "go-difflib",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "group": "github.com/stretchr",
-      "name": "objx",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-      "group": "gopkg.in",
-      "name": "yaml.v2",
-      "version": "v2.4.0",
-      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-      "group": "github.com/go-openapi",
-      "name": "jsonreference",
-      "version": "v0.20.0",
-      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-      "group": "github.com/go-openapi",
-      "name": "jsonpointer",
-      "version": "v0.19.5",
-      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/go.opencensus.io@v0.22.4",
-      "name": "go.opencensus.io",
-      "version": "v0.22.4",
-      "purl": "pkg:golang/go.opencensus.io@v0.22.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-      "group": "github.com/golang",
-      "name": "groupcache",
-      "version": "v0.0.0-20210331224755-41bb18bfe9da",
-      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-      "group": "github.com/golang",
-      "name": "protobuf",
-      "version": "v1.5.2",
-      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-      "group": "github.com/google",
-      "name": "go-cmp",
-      "version": "v0.5.9",
-      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0",
-      "group": "golang.org/x",
-      "name": "net",
-      "version": "v0.10.0",
-      "purl": "pkg:golang/golang.org/x/net@v0.10.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-      "group": "golang.org/x",
-      "name": "sys",
-      "version": "v0.8.0",
-      "purl": "pkg:golang/golang.org/x/sys@v0.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0",
-      "group": "golang.org/x",
-      "name": "text",
-      "version": "v0.9.0",
-      "purl": "pkg:golang/golang.org/x/text@v0.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-      "group": "google.golang.org",
-      "name": "genproto",
-      "version": "v0.0.0-20201019141844-1ed22bb0c154",
-      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
-      "group": "google.golang.org",
-      "name": "grpc",
-      "version": "v1.31.0",
-      "purl": "pkg:golang/google.golang.org/grpc@v1.31.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-      "group": "k8s.io/klog",
-      "name": "v2",
-      "version": "v2.80.1",
-      "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
-      "group": "github.com/go-logr",
-      "name": "logr",
-      "version": "v1.2.3",
-      "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-      "group": "golang.org/x",
-      "name": "image",
-      "version": "v0.0.0-20190802002840-cff245a6509b",
-      "purl": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-      "group": "github.com/mailru",
-      "name": "easyjson",
-      "version": "v0.7.6",
-      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-      "group": "github.com/josharian",
-      "name": "intern",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-      "group": "github.com/cncf/udpa",
-      "name": "go",
-      "version": "v0.0.0-20191209042840-269d4d468f6f",
-      "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-      "group": "github.com/envoyproxy",
-      "name": "protoc-gen-validate",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-      "group": "cloud.google.com/go",
-      "name": "bigquery",
-      "version": "v1.8.0",
-      "purl": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-      "group": "cloud.google.com",
-      "name": "go",
-      "version": "v0.65.0",
-      "purl": "pkg:golang/cloud.google.com/go@v0.65.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-      "group": "cloud.google.com/go",
-      "name": "storage",
-      "version": "v1.10.0",
-      "purl": "pkg:golang/cloud.google.com/go/storage@v1.10.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-      "group": "github.com/googleapis/gax-go",
-      "name": "v2",
-      "version": "v2.0.5",
-      "purl": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-      "group": "golang.org/x",
-      "name": "exp",
-      "version": "v0.0.0-20200224162631-6cc2880d07d6",
-      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-      "group": "golang.org/x",
-      "name": "lint",
-      "version": "v0.0.0-20200302205851-738671d3881b",
-      "purl": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-      "group": "golang.org/x",
-      "name": "tools",
-      "version": "v0.6.0",
-      "purl": "pkg:golang/golang.org/x/tools@v0.6.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/api@v0.30.0",
-      "group": "google.golang.org",
-      "name": "api",
-      "version": "v0.30.0",
-      "purl": "pkg:golang/google.golang.org/api@v0.30.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-      "group": "gopkg.in",
-      "name": "check.v1",
-      "version": "v1.0.0-20200227125254-8fa46927fb4f",
-      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "group": "golang.org/x",
-      "name": "xerrors",
-      "version": "v0.0.0-20200804184101-5ec99f83aff1",
-      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-      "group": "github.com/emicklei/go-restful",
-      "name": "v3",
-      "version": "v3.9.0",
-      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-      "group": "github.com/gin-gonic",
-      "name": "gin",
-      "version": "v1.9.1",
-      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-      "group": "github.com/go-openapi",
-      "name": "swag",
-      "version": "v0.19.14",
-      "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-      "group": "github.com/gogo",
-      "name": "protobuf",
-      "version": "v1.3.2",
-      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-      "group": "github.com/google",
-      "name": "gnostic",
-      "version": "v0.5.7-v3refs",
-      "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-      "group": "github.com/google",
-      "name": "gofuzz",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2",
-      "group": "github.com/google",
-      "name": "uuid",
-      "version": "v1.1.2",
-      "purl": "pkg:golang/github.com/google/uuid@v1.1.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-      "group": "github.com/imdario",
-      "name": "mergo",
-      "version": "v0.3.6",
-      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
-      "group": "github.com/jessevdk",
-      "name": "go-flags",
-      "version": "v1.5.0",
-      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-      "group": "github.com/json-iterator",
-      "name": "go",
-      "version": "v1.1.12",
-      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
-      "group": "github.com/kr",
-      "name": "pretty",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/kr/pretty@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0",
-      "group": "github.com/kr",
-      "name": "text",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/kr/text@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-      "group": "github.com/modern-go",
-      "name": "concurrent",
-      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-      "group": "github.com/modern-go",
-      "name": "reflect2",
-      "version": "v1.0.2",
-      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-      "group": "github.com/munnerz",
-      "name": "goautoneg",
-      "version": "v0.0.0-20191010083416-a7dc8b61c822",
-      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-      "group": "github.com/rogpeppe",
-      "name": "go-internal",
-      "version": "v1.9.0",
-      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-      "group": "github.com/spf13",
-      "name": "pflag",
-      "version": "v1.0.5",
-      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-      "group": "golang.org/x",
-      "name": "oauth2",
-      "version": "v0.0.0-20220223155221-ee480838109b",
-      "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0",
-      "group": "golang.org/x",
-      "name": "term",
-      "version": "v0.8.0",
-      "purl": "pkg:golang/golang.org/x/term@v0.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-      "group": "golang.org/x",
-      "name": "time",
-      "version": "v0.0.0-20220210224613-90d013bbcef8",
-      "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-      "group": "google.golang.org",
-      "name": "appengine",
-      "version": "v1.6.7",
-      "purl": "pkg:golang/google.golang.org/appengine@v1.6.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-      "group": "google.golang.org",
-      "name": "protobuf",
-      "version": "v1.30.0",
-      "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-      "group": "gopkg.in",
-      "name": "inf.v0",
-      "version": "v0.9.1",
-      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "group": "gopkg.in",
-      "name": "yaml.v3",
-      "version": "v3.0.1",
-      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/api@v0.26.1",
-      "group": "k8s.io",
-      "name": "api",
-      "version": "v0.26.1",
-      "purl": "pkg:golang/k8s.io/api@v0.26.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
-      "group": "k8s.io",
-      "name": "apimachinery",
-      "version": "v0.26.1",
-      "purl": "pkg:golang/k8s.io/apimachinery@v0.26.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1",
-      "group": "k8s.io",
-      "name": "client-go",
-      "version": "v0.26.1",
-      "purl": "pkg:golang/k8s.io/client-go@v0.26.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-      "group": "k8s.io",
-      "name": "kube-openapi",
-      "version": "v0.0.0-20221012153701-172d655c2280",
-      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-      "group": "k8s.io",
-      "name": "utils",
-      "version": "v0.0.0-20221107191617-1a15be271d1d",
-      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-      "group": "sigs.k8s.io",
-      "name": "json",
-      "version": "v0.0.0-20220713155537-f223a00ba0e2",
-      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-      "group": "sigs.k8s.io/structured-merge-diff",
-      "name": "v4",
-      "version": "v4.2.3",
-      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-      "group": "sigs.k8s.io",
-      "name": "yaml",
-      "version": "v1.3.0",
-      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-      "group": "golang.org/x",
-      "name": "mod",
-      "version": "v0.8.0",
-      "purl": "pkg:golang/golang.org/x/mod@v0.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-      "group": "golang.org/x",
-      "name": "crypto",
-      "version": "v0.9.0",
-      "purl": "pkg:golang/golang.org/x/crypto@v0.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-      "group": "github.com/kisielk",
-      "name": "errcheck",
-      "version": "v1.5.0",
-      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-      "group": "github.com/kisielk",
-      "name": "gotool",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-      "group": "honnef.co/go",
-      "name": "tools",
-      "version": "v0.0.1-2020.1.4",
-      "purl": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/mock@v1.4.4",
-      "group": "github.com/golang",
-      "name": "mock",
-      "version": "v1.4.4",
-      "purl": "pkg:golang/github.com/golang/mock@v1.4.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
-      "group": "rsc.io/quote",
-      "name": "v3",
-      "version": "v3.1.0",
-      "purl": "pkg:golang/rsc.io/quote/v3@v3.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-      "group": "github.com/niemeyer",
-      "name": "pretty",
-      "version": "v0.0.0-20200227124842-a10e7caefd8e",
-      "purl": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-      "group": "golang.org/x",
-      "name": "mobile",
-      "version": "v0.0.0-20190719004257-d2bd2a29d028",
-      "purl": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-      "group": "github.com/armon",
-      "name": "go-socks5",
-      "version": "v0.0.0-20160902184237-e75332964ef5",
-      "purl": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-      "group": "github.com/elazarl",
-      "name": "goproxy",
-      "version": "v0.0.0-20180725130230-947c36da3153",
-      "purl": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-      "group": "github.com/evanphx",
-      "name": "json-patch",
-      "version": "v4.12.0+incompatible",
-      "purl": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-      "group": "github.com/moby",
-      "name": "spdystream",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-      "group": "github.com/mxk",
-      "name": "go-flowrate",
-      "version": "v0.0.0-20140419014527-cca7078d478f",
-      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-      "group": "github.com/onsi/ginkgo",
-      "name": "v2",
-      "version": "v2.4.0",
-      "purl": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
-      "group": "github.com/onsi",
-      "name": "gomega",
-      "version": "v1.23.0",
-      "purl": "pkg:golang/github.com/onsi/gomega@v1.23.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
-      "group": "github.com/pkg",
-      "name": "errors",
-      "version": "v0.9.1",
-      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
-      "group": "github.com/google/martian",
-      "name": "v3",
-      "version": "v3.0.0",
-      "purl": "pkg:golang/github.com/google/martian/v3@v3.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-      "group": "github.com/envoyproxy",
-      "name": "go-control-plane",
-      "version": "v0.9.4",
-      "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-      "group": "github.com/census-instrumentation",
-      "name": "opencensus-proto",
-      "version": "v0.2.1",
-      "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-      "group": "github.com/prometheus",
-      "name": "client_model",
-      "version": "v0.0.0-20190812154241-14fe0d1b01d4",
-      "purl": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-      "group": "github.com/bytedance",
-      "name": "sonic",
-      "version": "v1.9.1",
-      "purl": "pkg:golang/github.com/bytedance/sonic@v1.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "group": "github.com/gin-contrib",
-      "name": "sse",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-      "group": "github.com/go-playground/validator",
-      "name": "v10",
-      "version": "v10.14.0",
-      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-      "group": "github.com/goccy",
-      "name": "go-json",
-      "version": "v0.10.2",
-      "purl": "pkg:golang/github.com/goccy/go-json@v0.10.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-      "group": "github.com/mattn",
-      "name": "go-isatty",
-      "version": "v0.0.19",
-      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-      "group": "github.com/pelletier/go-toml",
-      "name": "v2",
-      "version": "v2.0.8",
-      "purl": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-      "group": "github.com/ugorji/go",
-      "name": "codec",
-      "version": "v1.2.11",
-      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-      "group": "github.com/chenzhuoyu",
-      "name": "base64x",
-      "version": "v0.0.0-20221115062448-fe3a3abad311",
-      "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-      "group": "github.com/gabriel-vasile",
-      "name": "mimetype",
-      "version": "v1.4.2",
-      "purl": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-      "group": "github.com/go-playground",
-      "name": "locales",
-      "version": "v0.14.1",
-      "purl": "pkg:golang/github.com/go-playground/locales@v0.14.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-      "group": "github.com/go-playground",
-      "name": "universal-translator",
-      "version": "v0.18.1",
-      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-      "group": "github.com/klauspost/cpuid",
-      "name": "v2",
-      "version": "v2.2.4",
-      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-      "group": "github.com/leodido",
-      "name": "go-urn",
-      "version": "v1.2.4",
-      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-      "group": "github.com/twitchyliquid64",
-      "name": "golang-asm",
-      "version": "v0.15.1",
-      "purl": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-      "group": "golang.org/x",
-      "name": "arch",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/golang.org/x/arch@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-      "group": "golang.org/x",
-      "name": "sync",
-      "version": "v0.0.0-20201020160332-67f06af15bc9",
-      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-      "group": "github.com/gregjones",
-      "name": "httpcache",
-      "version": "v0.0.0-20180305231024-9cad4c3443a7",
-      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-      "group": "github.com/peterbourgon",
-      "name": "diskv",
-      "version": "v2.0.1+incompatible",
-      "purl": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1",
-      "group": "github.com/google",
-      "name": "btree",
-      "version": "v1.0.1",
-      "purl": "pkg:golang/github.com/google/btree@v1.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-      "group": "github.com/pkg",
-      "name": "diff",
-      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
-      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "group": "github.com/hashicorp",
-      "name": "golang-lru",
-      "version": "v0.5.1",
-      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-      "group": "github.com/burntsushi",
-      "name": "toml",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/burntsushi/toml@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/renameio@v0.1.0",
-      "group": "github.com/google",
-      "name": "renameio",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/google/renameio@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-      "group": "github.com/google",
-      "name": "pprof",
-      "version": "v0.0.0-20200708004538-1a94d8640e99",
-      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
-      "group": "github.com/chzyer",
-      "name": "logex",
-      "version": "v1.1.10",
-      "purl": "pkg:golang/github.com/chzyer/logex@v1.1.10"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-      "group": "github.com/chzyer",
-      "name": "readline",
-      "version": "v0.0.0-20180603132655-2972be24d48e",
-      "purl": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-      "group": "github.com/chzyer",
-      "name": "test",
-      "version": "v0.0.0-20180213035817-a1ea475d72b1",
-      "purl": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-      "group": "github.com/ianlancetaylor",
-      "name": "demangle",
-      "version": "v0.0.0-20181102032728-5e5cf60278f6",
-      "purl": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-      "group": "cloud.google.com/go",
-      "name": "pubsub",
-      "version": "v1.3.1",
-      "purl": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-      "group": "github.com/nytimes",
-      "name": "gziphandler",
-      "version": "v0.0.0-20170623195520-56545f4a5d46",
-      "purl": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-      "group": "github.com/asaskevich",
-      "name": "govalidator",
-      "version": "v0.0.0-20190424111038-f61b66f89f4a",
-      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-      "group": "github.com/mitchellh",
-      "name": "mapstructure",
-      "version": "v1.1.2",
-      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-      "group": "k8s.io",
-      "name": "gengo",
-      "version": "v0.0.0-20210813121822-485abfe95c7c",
-      "purl": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-      "group": "github.com/puerkitobio",
-      "name": "purell",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-      "group": "github.com/puerkitobio",
-      "name": "urlesc",
-      "version": "v0.0.0-20170810143723-de5bf2ad4578",
-      "purl": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-      "group": "cloud.google.com/go",
-      "name": "datastore",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-      "group": "github.com/creack",
-      "name": "pty",
-      "version": "v1.1.9",
-      "purl": "pkg:golang/github.com/creack/pty@v1.1.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-      "group": "github.com/golang",
-      "name": "glog",
-      "version": "v0.0.0-20160126235308-23def4e6c14b",
-      "purl": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/rsc.io/sampler@v1.3.0",
-      "group": "rsc.io",
-      "name": "sampler",
-      "version": "v1.3.0",
-      "purl": "pkg:golang/rsc.io/sampler@v1.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-      "group": "dmitri.shuralyov.com/gpu",
-      "name": "mtl",
-      "version": "v0.0.0-20190408044501-666a987793e9",
-      "purl": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-      "group": "github.com/burntsushi",
-      "name": "xgb",
-      "version": "v0.0.0-20160522181843-27f122750802",
-      "purl": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-      "group": "github.com/go-gl/glfw/v3.3",
-      "name": "glfw",
-      "version": "v0.0.0-20200222043503-6f7a984d4dc4",
-      "purl": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-      "group": "github.com/google",
-      "name": "martian",
-      "version": "v2.1.0+incompatible",
-      "purl": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-      "group": "github.com/jstemmer",
-      "name": "go-junit-report",
-      "version": "v0.9.1",
-      "purl": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-      "group": "rsc.io",
-      "name": "binaryregexp",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-      "group": "github.com/stoewer",
-      "name": "go-strcase",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-      "group": "github.com/docopt",
-      "name": "docopt-go",
-      "version": "v0.0.0-20180111231733-ee0de3bc6815",
-      "purl": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-      "group": "gopkg.in",
-      "name": "errgo.v2",
-      "version": "v2.1.0",
-      "purl": "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-        "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-        "pkg:golang/github.com/go-logr/logr@v1.2.3",
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/imdario/mergo@v0.3.6",
-        "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
-        "pkg:golang/github.com/josharian/intern@v1.0.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/kr/pretty@v0.3.1",
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/term@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/google.golang.org/appengine@v1.6.7",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/k8s.io/api@v0.26.1",
-        "pkg:golang/k8s.io/apimachinery@v0.26.1",
-        "pkg:golang/k8s.io/client-go@v0.26.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/stretchr/objx@v0.1.0",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-      "dependsOn": [
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/go.opencensus.io@v0.22.4",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/net@v0.10.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.9.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/text@v0.9.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
-      "dependsOn": [
-        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-        "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-        "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-      "dependsOn": [
-        "pkg:golang/github.com/go-logr/logr@v1.2.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-      "dependsOn": [
-        "pkg:golang/github.com/josharian/intern@v1.0.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-      "dependsOn": [
-        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-        "pkg:golang/github.com/golang/mock@v1.4.4",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/btree@v1.0.1",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-        "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-        "pkg:golang/go.opencensus.io@v0.22.4",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-        "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-      "dependsOn": [
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-      "dependsOn": [
-        "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-        "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-        "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-        "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-        "pkg:golang/golang.org/x/mod@v0.8.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/google.golang.org/appengine@v1.6.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/api@v0.30.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/go.opencensus.io@v0.22.4",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/appengine@v1.6.7",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-      "dependsOn": [
-        "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-        "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-        "pkg:golang/github.com/goccy/go-json@v0.10.2",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-        "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-        "pkg:golang/github.com/go-playground/locales@v0.14.1",
-        "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-        "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-        "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-        "pkg:golang/golang.org/x/arch@v0.3.0",
-        "pkg:golang/golang.org/x/crypto@v0.9.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-      "dependsOn": [
-        "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/kr/pretty@v0.3.1",
-        "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/text@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/creack/pty@v1.1.9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/google.golang.org/appengine@v1.6.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/term@v0.8.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/api@v0.26.1",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/k8s.io/apimachinery@v0.26.1",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/go-logr/logr@v1.2.3",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
-      "dependsOn": [
-        "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/moby/spdystream@v0.2.0",
-        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-        "pkg:golang/github.com/go-logr/logr@v1.2.3",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-        "pkg:golang/github.com/onsi/gomega@v1.23.0",
-        "pkg:golang/github.com/pkg/errors@v0.9.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/client-go@v0.26.1",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-        "pkg:golang/github.com/imdario/mergo@v0.3.6",
-        "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/term@v0.8.0",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/k8s.io/api@v0.26.1",
-        "pkg:golang/k8s.io/apimachinery@v0.26.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-        "pkg:golang/github.com/go-logr/logr@v1.2.3",
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/google/btree@v1.0.1",
-        "pkg:golang/github.com/josharian/intern@v1.0.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/moby/spdystream@v0.2.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-        "pkg:golang/github.com/pkg/errors@v0.9.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/appengine@v1.6.7",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-      "dependsOn": [
-        "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-        "pkg:golang/github.com/onsi/gomega@v1.23.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-        "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-        "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/go-logr/logr@v1.2.3",
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/golang.org/x/mod@v0.8.0",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/github.com/go-logr/logr@v1.2.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-      ]
-    },
-    {
-      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-      "dependsOn": [
-        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-        "pkg:golang/github.com/google/renameio@v0.1.0",
-        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-        "pkg:golang/golang.org/x/mod@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/mock@v1.4.4",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/rsc.io/quote/v3@v3.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
-      "dependsOn": [
-        "pkg:golang/rsc.io/sampler@v1.3.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/text@v0.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.10.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-      "dependsOn": [
-        "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/btree@v1.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/renameio@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-      "dependsOn": [
-        "pkg:golang/github.com/chzyer/logex@v1.1.10",
-        "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-        "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-        "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/go.opencensus.io@v0.22.4",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/rsc.io/sampler@v1.3.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/pretty@v0.3.1",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-      ]
-    }
-  ]
+  "components" : [ {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
+    "group" : "github.com/stretchr",
+    "name" : "testify",
+    "version" : "v1.8.3",
+    "purl" : "pkg:golang/github.com/stretchr/testify@v1.8.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "group" : "github.com/davecgh",
+    "name" : "go-spew",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "group" : "github.com/pmezard",
+    "name" : "go-difflib",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "group" : "github.com/stretchr",
+    "name" : "objx",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+    "group" : "gopkg.in",
+    "name" : "yaml.v2",
+    "version" : "v2.4.0",
+    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+    "group" : "gopkg.in",
+    "name" : "yaml.v3",
+    "version" : "v3.0.1",
+    "purl" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/go.opencensus.io@v0.22.4",
+    "name" : "go.opencensus.io",
+    "version" : "v0.22.4",
+    "purl" : "pkg:golang/go.opencensus.io@v0.22.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
+    "group" : "github.com/golang",
+    "name" : "protobuf",
+    "version" : "v1.5.2",
+    "purl" : "pkg:golang/github.com/golang/protobuf@v1.5.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
+    "group" : "github.com/google",
+    "name" : "go-cmp",
+    "version" : "v0.5.9",
+    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "group" : "github.com/hashicorp",
+    "name" : "golang-lru",
+    "version" : "v0.5.1",
+    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/net@v0.10.0",
+    "group" : "golang.org/x",
+    "name" : "net",
+    "version" : "v0.10.0",
+    "purl" : "pkg:golang/golang.org/x/net@v0.10.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+    "group" : "google.golang.org",
+    "name" : "genproto",
+    "version" : "v0.0.0-20201019141844-1ed22bb0c154",
+    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
+    "group" : "google.golang.org",
+    "name" : "grpc",
+    "version" : "v1.31.0",
+    "purl" : "pkg:golang/google.golang.org/grpc@v1.31.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+    "group" : "github.com/golang",
+    "name" : "groupcache",
+    "version" : "v0.0.0-20210331224755-41bb18bfe9da",
+    "purl" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
+    "group" : "golang.org/x",
+    "name" : "sys",
+    "version" : "v0.8.0",
+    "purl" : "pkg:golang/golang.org/x/sys@v0.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/text@v0.9.0",
+    "group" : "golang.org/x",
+    "name" : "text",
+    "version" : "v0.9.0",
+    "purl" : "pkg:golang/golang.org/x/text@v0.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+    "group" : "github.com/go-openapi",
+    "name" : "jsonreference",
+    "version" : "v0.20.0",
+    "purl" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+    "group" : "github.com/go-openapi",
+    "name" : "jsonpointer",
+    "version" : "v0.19.5",
+    "purl" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
+    "group" : "k8s.io/klog",
+    "name" : "v2",
+    "version" : "v2.80.1",
+    "purl" : "pkg:golang/k8s.io/klog/v2@v2.80.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-logr/logr@v1.2.3",
+    "group" : "github.com/go-logr",
+    "name" : "logr",
+    "version" : "v1.2.3",
+    "purl" : "pkg:golang/github.com/go-logr/logr@v1.2.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+    "group" : "golang.org/x",
+    "name" : "image",
+    "version" : "v0.0.0-20190802002840-cff245a6509b",
+    "purl" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+    "group" : "github.com/mailru",
+    "name" : "easyjson",
+    "version" : "v0.7.6",
+    "purl" : "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
+    "group" : "github.com/josharian",
+    "name" : "intern",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/josharian/intern@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+    "group" : "github.com/cncf/udpa",
+    "name" : "go",
+    "version" : "v0.0.0-20191209042840-269d4d468f6f",
+    "purl" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+    "group" : "github.com/envoyproxy",
+    "name" : "protoc-gen-validate",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+    "group" : "cloud.google.com/go",
+    "name" : "bigquery",
+    "version" : "v1.8.0",
+    "purl" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
+    "group" : "cloud.google.com",
+    "name" : "go",
+    "version" : "v0.65.0",
+    "purl" : "pkg:golang/cloud.google.com/go@v0.65.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+    "group" : "cloud.google.com/go",
+    "name" : "storage",
+    "version" : "v1.10.0",
+    "purl" : "pkg:golang/cloud.google.com/go/storage@v1.10.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+    "group" : "github.com/googleapis/gax-go",
+    "name" : "v2",
+    "version" : "v2.0.5",
+    "purl" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
+    "group" : "golang.org/x",
+    "name" : "tools",
+    "version" : "v0.6.0",
+    "purl" : "pkg:golang/golang.org/x/tools@v0.6.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/api@v0.30.0",
+    "group" : "google.golang.org",
+    "name" : "api",
+    "version" : "v0.30.0",
+    "purl" : "pkg:golang/google.golang.org/api@v0.30.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+    "group" : "golang.org/x",
+    "name" : "exp",
+    "version" : "v0.0.0-20200224162631-6cc2880d07d6",
+    "purl" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
+    "group" : "golang.org/x",
+    "name" : "mod",
+    "version" : "v0.8.0",
+    "purl" : "pkg:golang/golang.org/x/mod@v0.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+    "group" : "honnef.co/go",
+    "name" : "tools",
+    "version" : "v0.0.1-2020.1.4",
+    "purl" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+    "group" : "cloud.google.com/go",
+    "name" : "pubsub",
+    "version" : "v1.3.1",
+    "purl" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
+    "group" : "google.golang.org",
+    "name" : "appengine",
+    "version" : "v1.6.7",
+    "purl" : "pkg:golang/google.golang.org/appengine@v1.6.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+    "group" : "golang.org/x",
+    "name" : "lint",
+    "version" : "v0.0.0-20200302205851-738671d3881b",
+    "purl" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+    "group" : "gopkg.in",
+    "name" : "check.v1",
+    "version" : "v1.0.0-20200227125254-8fa46927fb4f",
+    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+    "group" : "github.com/emicklei/go-restful",
+    "name" : "v3",
+    "version" : "v3.9.0",
+    "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+    "group" : "github.com/gin-gonic",
+    "name" : "gin",
+    "version" : "v1.9.1",
+    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+    "group" : "github.com/go-openapi",
+    "name" : "swag",
+    "version" : "v0.19.14",
+    "purl" : "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+    "group" : "github.com/gogo",
+    "name" : "protobuf",
+    "version" : "v1.3.2",
+    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+    "group" : "github.com/google",
+    "name" : "gnostic",
+    "version" : "v0.5.7-v3refs",
+    "purl" : "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
+    "group" : "github.com/google",
+    "name" : "gofuzz",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/google/gofuzz@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
+    "group" : "github.com/google",
+    "name" : "uuid",
+    "version" : "v1.1.2",
+    "purl" : "pkg:golang/github.com/google/uuid@v1.1.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
+    "group" : "github.com/imdario",
+    "name" : "mergo",
+    "version" : "v0.3.6",
+    "purl" : "pkg:golang/github.com/imdario/mergo@v0.3.6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+    "group" : "github.com/jessevdk",
+    "name" : "go-flags",
+    "version" : "v1.5.0",
+    "purl" : "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
+    "group" : "github.com/json-iterator",
+    "name" : "go",
+    "version" : "v1.1.12",
+    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.12"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
+    "group" : "github.com/kr",
+    "name" : "pretty",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/kr/pretty@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/text@v0.2.0",
+    "group" : "github.com/kr",
+    "name" : "text",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/kr/text@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+    "group" : "github.com/modern-go",
+    "name" : "concurrent",
+    "version" : "v0.0.0-20180306012644-bacd9c7ef1dd",
+    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+    "group" : "github.com/modern-go",
+    "name" : "reflect2",
+    "version" : "v1.0.2",
+    "purl" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+    "group" : "github.com/munnerz",
+    "name" : "goautoneg",
+    "version" : "v0.0.0-20191010083416-a7dc8b61c822",
+    "purl" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+    "group" : "github.com/rogpeppe",
+    "name" : "go-internal",
+    "version" : "v1.9.0",
+    "purl" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
+    "group" : "github.com/spf13",
+    "name" : "pflag",
+    "version" : "v1.0.5",
+    "purl" : "pkg:golang/github.com/spf13/pflag@v1.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+    "group" : "golang.org/x",
+    "name" : "oauth2",
+    "version" : "v0.0.0-20220223155221-ee480838109b",
+    "purl" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/term@v0.8.0",
+    "group" : "golang.org/x",
+    "name" : "term",
+    "version" : "v0.8.0",
+    "purl" : "pkg:golang/golang.org/x/term@v0.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+    "group" : "golang.org/x",
+    "name" : "time",
+    "version" : "v0.0.0-20220210224613-90d013bbcef8",
+    "purl" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
+    "group" : "google.golang.org",
+    "name" : "protobuf",
+    "version" : "v1.30.0",
+    "purl" : "pkg:golang/google.golang.org/protobuf@v1.30.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+    "group" : "gopkg.in",
+    "name" : "inf.v0",
+    "version" : "v0.9.1",
+    "purl" : "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/api@v0.26.1",
+    "group" : "k8s.io",
+    "name" : "api",
+    "version" : "v0.26.1",
+    "purl" : "pkg:golang/k8s.io/api@v0.26.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
+    "group" : "k8s.io",
+    "name" : "apimachinery",
+    "version" : "v0.26.1",
+    "purl" : "pkg:golang/k8s.io/apimachinery@v0.26.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
+    "group" : "k8s.io",
+    "name" : "client-go",
+    "version" : "v0.26.1",
+    "purl" : "pkg:golang/k8s.io/client-go@v0.26.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+    "group" : "k8s.io",
+    "name" : "kube-openapi",
+    "version" : "v0.0.0-20221012153701-172d655c2280",
+    "purl" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+    "group" : "k8s.io",
+    "name" : "utils",
+    "version" : "v0.0.0-20221107191617-1a15be271d1d",
+    "purl" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+    "group" : "sigs.k8s.io",
+    "name" : "json",
+    "version" : "v0.0.0-20220713155537-f223a00ba0e2",
+    "purl" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+    "group" : "sigs.k8s.io/structured-merge-diff",
+    "name" : "v4",
+    "version" : "v4.2.3",
+    "purl" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+    "group" : "sigs.k8s.io",
+    "name" : "yaml",
+    "version" : "v1.3.0",
+    "purl" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "group" : "golang.org/x",
+    "name" : "xerrors",
+    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
+    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
+    "group" : "golang.org/x",
+    "name" : "crypto",
+    "version" : "v0.9.0",
+    "purl" : "pkg:golang/golang.org/x/crypto@v0.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+    "group" : "github.com/kisielk",
+    "name" : "errcheck",
+    "version" : "v1.5.0",
+    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "group" : "github.com/kisielk",
+    "name" : "gotool",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
+    "group" : "github.com/golang",
+    "name" : "mock",
+    "version" : "v1.4.4",
+    "purl" : "pkg:golang/github.com/golang/mock@v1.4.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
+    "group" : "rsc.io/quote",
+    "name" : "v3",
+    "version" : "v3.1.0",
+    "purl" : "pkg:golang/rsc.io/quote/v3@v3.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+    "group" : "golang.org/x",
+    "name" : "sync",
+    "version" : "v0.0.0-20201020160332-67f06af15bc9",
+    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+    "group" : "github.com/niemeyer",
+    "name" : "pretty",
+    "version" : "v0.0.0-20200227124842-a10e7caefd8e",
+    "purl" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+    "group" : "golang.org/x",
+    "name" : "mobile",
+    "version" : "v0.0.0-20190719004257-d2bd2a29d028",
+    "purl" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+    "group" : "github.com/armon",
+    "name" : "go-socks5",
+    "version" : "v0.0.0-20160902184237-e75332964ef5",
+    "purl" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+    "group" : "github.com/elazarl",
+    "name" : "goproxy",
+    "version" : "v0.0.0-20180725130230-947c36da3153",
+    "purl" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+    "group" : "github.com/evanphx",
+    "name" : "json-patch",
+    "version" : "v4.12.0+incompatible",
+    "purl" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
+    "group" : "github.com/moby",
+    "name" : "spdystream",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/moby/spdystream@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+    "group" : "github.com/mxk",
+    "name" : "go-flowrate",
+    "version" : "v0.0.0-20140419014527-cca7078d478f",
+    "purl" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+    "group" : "github.com/onsi/ginkgo",
+    "name" : "v2",
+    "version" : "v2.4.0",
+    "purl" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
+    "group" : "github.com/onsi",
+    "name" : "gomega",
+    "version" : "v1.23.0",
+    "purl" : "pkg:golang/github.com/onsi/gomega@v1.23.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
+    "group" : "github.com/pkg",
+    "name" : "errors",
+    "version" : "v0.9.1",
+    "purl" : "pkg:golang/github.com/pkg/errors@v0.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
+    "group" : "github.com/google/martian",
+    "name" : "v3",
+    "version" : "v3.0.0",
+    "purl" : "pkg:golang/github.com/google/martian/v3@v3.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+    "group" : "github.com/envoyproxy",
+    "name" : "go-control-plane",
+    "version" : "v0.9.4",
+    "purl" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+    "group" : "github.com/census-instrumentation",
+    "name" : "opencensus-proto",
+    "version" : "v0.2.1",
+    "purl" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+    "group" : "github.com/prometheus",
+    "name" : "client_model",
+    "version" : "v0.0.0-20190812154241-14fe0d1b01d4",
+    "purl" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+    "group" : "github.com/bytedance",
+    "name" : "sonic",
+    "version" : "v1.9.1",
+    "purl" : "pkg:golang/github.com/bytedance/sonic@v1.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "group" : "github.com/gin-contrib",
+    "name" : "sse",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+    "group" : "github.com/go-playground/validator",
+    "name" : "v10",
+    "version" : "v10.14.0",
+    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
+    "group" : "github.com/goccy",
+    "name" : "go-json",
+    "version" : "v0.10.2",
+    "purl" : "pkg:golang/github.com/goccy/go-json@v0.10.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+    "group" : "github.com/mattn",
+    "name" : "go-isatty",
+    "version" : "v0.0.19",
+    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+    "group" : "github.com/pelletier/go-toml",
+    "name" : "v2",
+    "version" : "v2.0.8",
+    "purl" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+    "group" : "github.com/ugorji/go",
+    "name" : "codec",
+    "version" : "v1.2.11",
+    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+    "group" : "github.com/chenzhuoyu",
+    "name" : "base64x",
+    "version" : "v0.0.0-20221115062448-fe3a3abad311",
+    "purl" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+    "group" : "github.com/gabriel-vasile",
+    "name" : "mimetype",
+    "version" : "v1.4.2",
+    "purl" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
+    "group" : "github.com/go-playground",
+    "name" : "locales",
+    "version" : "v0.14.1",
+    "purl" : "pkg:golang/github.com/go-playground/locales@v0.14.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+    "group" : "github.com/go-playground",
+    "name" : "universal-translator",
+    "version" : "v0.18.1",
+    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+    "group" : "github.com/klauspost/cpuid",
+    "name" : "v2",
+    "version" : "v2.2.4",
+    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+    "group" : "github.com/leodido",
+    "name" : "go-urn",
+    "version" : "v1.2.4",
+    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+    "group" : "github.com/twitchyliquid64",
+    "name" : "golang-asm",
+    "version" : "v0.15.1",
+    "purl" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
+    "group" : "golang.org/x",
+    "name" : "arch",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/golang.org/x/arch@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+    "group" : "github.com/gregjones",
+    "name" : "httpcache",
+    "version" : "v0.0.0-20180305231024-9cad4c3443a7",
+    "purl" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+    "group" : "github.com/peterbourgon",
+    "name" : "diskv",
+    "version" : "v2.0.1+incompatible",
+    "purl" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/btree@v1.0.1",
+    "group" : "github.com/google",
+    "name" : "btree",
+    "version" : "v1.0.1",
+    "purl" : "pkg:golang/github.com/google/btree@v1.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+    "group" : "gopkg.in",
+    "name" : "errgo.v2",
+    "version" : "v2.1.0",
+    "purl" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+    "group" : "github.com/pkg",
+    "name" : "diff",
+    "version" : "v0.0.0-20210226163009-20ebb0f2a09e",
+    "purl" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+    "group" : "github.com/burntsushi",
+    "name" : "toml",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/burntsushi/toml@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
+    "group" : "github.com/google",
+    "name" : "renameio",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/google/renameio@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+    "group" : "github.com/google",
+    "name" : "pprof",
+    "version" : "v0.0.0-20200708004538-1a94d8640e99",
+    "purl" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
+    "group" : "github.com/chzyer",
+    "name" : "logex",
+    "version" : "v1.1.10",
+    "purl" : "pkg:golang/github.com/chzyer/logex@v1.1.10"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+    "group" : "github.com/chzyer",
+    "name" : "readline",
+    "version" : "v0.0.0-20180603132655-2972be24d48e",
+    "purl" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+    "group" : "github.com/chzyer",
+    "name" : "test",
+    "version" : "v0.0.0-20180213035817-a1ea475d72b1",
+    "purl" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+    "group" : "github.com/ianlancetaylor",
+    "name" : "demangle",
+    "version" : "v0.0.0-20181102032728-5e5cf60278f6",
+    "purl" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+    "group" : "github.com/nytimes",
+    "name" : "gziphandler",
+    "version" : "v0.0.0-20170623195520-56545f4a5d46",
+    "purl" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+    "group" : "github.com/asaskevich",
+    "name" : "govalidator",
+    "version" : "v0.0.0-20190424111038-f61b66f89f4a",
+    "purl" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+    "group" : "github.com/mitchellh",
+    "name" : "mapstructure",
+    "version" : "v1.1.2",
+    "purl" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+    "group" : "k8s.io",
+    "name" : "gengo",
+    "version" : "v0.0.0-20210813121822-485abfe95c7c",
+    "purl" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+    "group" : "github.com/puerkitobio",
+    "name" : "purell",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+    "group" : "github.com/puerkitobio",
+    "name" : "urlesc",
+    "version" : "v0.0.0-20170810143723-de5bf2ad4578",
+    "purl" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+    "group" : "github.com/jstemmer",
+    "name" : "go-junit-report",
+    "version" : "v0.9.1",
+    "purl" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+    "group" : "cloud.google.com/go",
+    "name" : "datastore",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "group" : "github.com/kr",
+    "name" : "pty",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
+    "group" : "github.com/creack",
+    "name" : "pty",
+    "version" : "v1.1.9",
+    "purl" : "pkg:golang/github.com/creack/pty@v1.1.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+    "group" : "github.com/yuin",
+    "name" : "goldmark",
+    "version" : "v1.2.1",
+    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+    "group" : "github.com/golang",
+    "name" : "glog",
+    "version" : "v0.0.0-20160126235308-23def4e6c14b",
+    "purl" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
+    "group" : "github.com/client9",
+    "name" : "misspell",
+    "version" : "v0.3.4",
+    "purl" : "pkg:golang/github.com/client9/misspell@v0.3.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
+    "group" : "rsc.io",
+    "name" : "sampler",
+    "version" : "v1.3.0",
+    "purl" : "pkg:golang/rsc.io/sampler@v1.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+    "group" : "dmitri.shuralyov.com/gpu",
+    "name" : "mtl",
+    "version" : "v0.0.0-20190408044501-666a987793e9",
+    "purl" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+    "group" : "github.com/burntsushi",
+    "name" : "xgb",
+    "version" : "v0.0.0-20160522181843-27f122750802",
+    "purl" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+    "group" : "github.com/go-gl/glfw/v3.3",
+    "name" : "glfw",
+    "version" : "v0.0.0-20200222043503-6f7a984d4dc4",
+    "purl" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+    "group" : "github.com/go-gl",
+    "name" : "glfw",
+    "version" : "v0.0.0-20190409004039-e6da0acd62b1",
+    "purl" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+    "group" : "github.com/google",
+    "name" : "martian",
+    "version" : "v2.1.0+incompatible",
+    "purl" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+    "group" : "rsc.io",
+    "name" : "binaryregexp",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+    "group" : "github.com/stoewer",
+    "name" : "go-strcase",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+    "group" : "github.com/docopt",
+    "name" : "docopt-go",
+    "version" : "v0.0.0-20180111231733-ee0de3bc6815",
+    "purl" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
+  } ],
+  "dependencies" : [ {
+    "ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/gin-gonic/gin@v1.9.1", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/jessevdk/go-flags@v1.5.0", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/client-go@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
+  }, {
+    "ref" : "pkg:golang/go.opencensus.io@v0.22.4",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
+    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/protobuf@v1.30.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
+    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/net@v0.10.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/term@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
+    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/client9/misspell@v0.3.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/text@v0.9.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+    "dependsOn" : [ "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
+    "dependsOn" : [ "pkg:golang/github.com/go-logr/logr@v1.2.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-logr/logr@v1.2.3",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+    "dependsOn" : [ "pkg:golang/github.com/josharian/intern@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/google.golang.org/grpc@v1.31.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b" ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible", "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/github.com/google/martian/v3@v3.0.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/rsc.io/binaryregexp@v0.2.0" ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+    "dependsOn" : [ "pkg:golang/google.golang.org/grpc@v1.31.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
+    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.2.1", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/api@v0.30.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/golang/protobuf@v1.5.2" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+    "dependsOn" : [ "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9", "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802", "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+    "dependsOn" : [ "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/google/renameio@v0.1.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+    "dependsOn" : [ "pkg:golang/github.com/bytedance/sonic@v1.9.1", "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.14.0", "pkg:golang/github.com/goccy/go-json@v0.10.2", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mattn/go-isatty@v0.0.19", "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/github.com/ugorji/go/codec@v1.2.11", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2", "pkg:golang/github.com/go-playground/locales@v0.14.1", "pkg:golang/github.com/go-playground/universal-translator@v0.18.1", "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4", "pkg:golang/github.com/leodido/go-urn@v1.2.4", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1", "pkg:golang/golang.org/x/arch@v0.3.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.5.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/stoewer/go-strcase@v1.2.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
+    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/text@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1", "pkg:golang/github.com/creack/pty@v1.1.9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+    "dependsOn" : [ "pkg:golang/gopkg.in/errgo.v2@v2.1.0", "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e" ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/term@v0.8.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/api@v0.26.1",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
+    "dependsOn" : [ "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+    "dependsOn" : [ "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46", "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/puerkitobio/purell@v1.1.1", "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/github.com/go-logr/logr@v1.2.3" ]
+  }, {
+    "ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+    "dependsOn" : [ "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd" ]
+  }, {
+    "ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/rsc.io/quote/v3@v3.1.0" ]
+  }, {
+    "ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
+    "dependsOn" : [ "pkg:golang/rsc.io/sampler@v1.3.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+    "dependsOn" : [ "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+    "dependsOn" : [ "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/github.com/google/go-cmp@v0.5.9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/btree@v1.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
+  }, {
+    "ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+    "dependsOn" : [ "pkg:golang/github.com/chzyer/logex@v1.1.10", "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e", "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1", "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+    "dependsOn" : [ ]
+  } ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_no_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_ignore/expected_sbom_stack_analysis.json
@@ -1,1399 +1,2262 @@
 {
-  "bomFormat" : "CycloneDX",
-  "specVersion" : "1.4",
-  "version" : 1,
-  "metadata" : {
-    "component" : {
-      "type" : "application",
-      "bom-ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-      "group" : "github.com/rhecosystemappeng/saasi",
-      "name" : "deployer",
-      "version" : "v0.0.0",
-      "purl" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+      "group": "github.com/rhecosystemappeng/saasi",
+      "name": "deployer",
+      "version": "v0.0.0",
+      "purl": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
     }
   },
-  "components" : [ {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
-    "group" : "github.com/stretchr",
-    "name" : "testify",
-    "version" : "v1.8.3",
-    "purl" : "pkg:golang/github.com/stretchr/testify@v1.8.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "group" : "github.com/davecgh",
-    "name" : "go-spew",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "group" : "github.com/pmezard",
-    "name" : "go-difflib",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "group" : "github.com/stretchr",
-    "name" : "objx",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-    "group" : "gopkg.in",
-    "name" : "yaml.v2",
-    "version" : "v2.4.0",
-    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-    "group" : "gopkg.in",
-    "name" : "yaml.v3",
-    "version" : "v3.0.1",
-    "purl" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/go.opencensus.io@v0.22.4",
-    "name" : "go.opencensus.io",
-    "version" : "v0.22.4",
-    "purl" : "pkg:golang/go.opencensus.io@v0.22.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
-    "group" : "github.com/golang",
-    "name" : "protobuf",
-    "version" : "v1.5.2",
-    "purl" : "pkg:golang/github.com/golang/protobuf@v1.5.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
-    "group" : "github.com/google",
-    "name" : "go-cmp",
-    "version" : "v0.5.9",
-    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "group" : "github.com/hashicorp",
-    "name" : "golang-lru",
-    "version" : "v0.5.1",
-    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/net@v0.10.0",
-    "group" : "golang.org/x",
-    "name" : "net",
-    "version" : "v0.10.0",
-    "purl" : "pkg:golang/golang.org/x/net@v0.10.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-    "group" : "google.golang.org",
-    "name" : "genproto",
-    "version" : "v0.0.0-20201019141844-1ed22bb0c154",
-    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
-    "group" : "google.golang.org",
-    "name" : "grpc",
-    "version" : "v1.31.0",
-    "purl" : "pkg:golang/google.golang.org/grpc@v1.31.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-    "group" : "github.com/golang",
-    "name" : "groupcache",
-    "version" : "v0.0.0-20210331224755-41bb18bfe9da",
-    "purl" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
-    "group" : "golang.org/x",
-    "name" : "sys",
-    "version" : "v0.8.0",
-    "purl" : "pkg:golang/golang.org/x/sys@v0.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/text@v0.9.0",
-    "group" : "golang.org/x",
-    "name" : "text",
-    "version" : "v0.9.0",
-    "purl" : "pkg:golang/golang.org/x/text@v0.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-    "group" : "github.com/go-openapi",
-    "name" : "jsonreference",
-    "version" : "v0.20.0",
-    "purl" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-    "group" : "github.com/go-openapi",
-    "name" : "jsonpointer",
-    "version" : "v0.19.5",
-    "purl" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
-    "group" : "k8s.io/klog",
-    "name" : "v2",
-    "version" : "v2.80.1",
-    "purl" : "pkg:golang/k8s.io/klog/v2@v2.80.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-logr/logr@v1.2.3",
-    "group" : "github.com/go-logr",
-    "name" : "logr",
-    "version" : "v1.2.3",
-    "purl" : "pkg:golang/github.com/go-logr/logr@v1.2.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-    "group" : "golang.org/x",
-    "name" : "image",
-    "version" : "v0.0.0-20190802002840-cff245a6509b",
-    "purl" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-    "group" : "github.com/mailru",
-    "name" : "easyjson",
-    "version" : "v0.7.6",
-    "purl" : "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
-    "group" : "github.com/josharian",
-    "name" : "intern",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/josharian/intern@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-    "group" : "github.com/cncf/udpa",
-    "name" : "go",
-    "version" : "v0.0.0-20191209042840-269d4d468f6f",
-    "purl" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-    "group" : "github.com/envoyproxy",
-    "name" : "protoc-gen-validate",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-    "group" : "cloud.google.com/go",
-    "name" : "bigquery",
-    "version" : "v1.8.0",
-    "purl" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
-    "group" : "cloud.google.com",
-    "name" : "go",
-    "version" : "v0.65.0",
-    "purl" : "pkg:golang/cloud.google.com/go@v0.65.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-    "group" : "cloud.google.com/go",
-    "name" : "storage",
-    "version" : "v1.10.0",
-    "purl" : "pkg:golang/cloud.google.com/go/storage@v1.10.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-    "group" : "github.com/googleapis/gax-go",
-    "name" : "v2",
-    "version" : "v2.0.5",
-    "purl" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
-    "group" : "golang.org/x",
-    "name" : "tools",
-    "version" : "v0.6.0",
-    "purl" : "pkg:golang/golang.org/x/tools@v0.6.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/api@v0.30.0",
-    "group" : "google.golang.org",
-    "name" : "api",
-    "version" : "v0.30.0",
-    "purl" : "pkg:golang/google.golang.org/api@v0.30.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-    "group" : "golang.org/x",
-    "name" : "exp",
-    "version" : "v0.0.0-20200224162631-6cc2880d07d6",
-    "purl" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
-    "group" : "golang.org/x",
-    "name" : "mod",
-    "version" : "v0.8.0",
-    "purl" : "pkg:golang/golang.org/x/mod@v0.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-    "group" : "honnef.co/go",
-    "name" : "tools",
-    "version" : "v0.0.1-2020.1.4",
-    "purl" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-    "group" : "cloud.google.com/go",
-    "name" : "pubsub",
-    "version" : "v1.3.1",
-    "purl" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
-    "group" : "google.golang.org",
-    "name" : "appengine",
-    "version" : "v1.6.7",
-    "purl" : "pkg:golang/google.golang.org/appengine@v1.6.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-    "group" : "golang.org/x",
-    "name" : "lint",
-    "version" : "v0.0.0-20200302205851-738671d3881b",
-    "purl" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-    "group" : "gopkg.in",
-    "name" : "check.v1",
-    "version" : "v1.0.0-20200227125254-8fa46927fb4f",
-    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-    "group" : "github.com/emicklei/go-restful",
-    "name" : "v3",
-    "version" : "v3.9.0",
-    "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-    "group" : "github.com/gin-gonic",
-    "name" : "gin",
-    "version" : "v1.9.1",
-    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-    "group" : "github.com/go-openapi",
-    "name" : "swag",
-    "version" : "v0.19.14",
-    "purl" : "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-    "group" : "github.com/gogo",
-    "name" : "protobuf",
-    "version" : "v1.3.2",
-    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-    "group" : "github.com/google",
-    "name" : "gnostic",
-    "version" : "v0.5.7-v3refs",
-    "purl" : "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
-    "group" : "github.com/google",
-    "name" : "gofuzz",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/google/gofuzz@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
-    "group" : "github.com/google",
-    "name" : "uuid",
-    "version" : "v1.1.2",
-    "purl" : "pkg:golang/github.com/google/uuid@v1.1.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
-    "group" : "github.com/imdario",
-    "name" : "mergo",
-    "version" : "v0.3.6",
-    "purl" : "pkg:golang/github.com/imdario/mergo@v0.3.6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
-    "group" : "github.com/jessevdk",
-    "name" : "go-flags",
-    "version" : "v1.5.0",
-    "purl" : "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
-    "group" : "github.com/json-iterator",
-    "name" : "go",
-    "version" : "v1.1.12",
-    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.12"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
-    "group" : "github.com/kr",
-    "name" : "pretty",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/kr/pretty@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/text@v0.2.0",
-    "group" : "github.com/kr",
-    "name" : "text",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/kr/text@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-    "group" : "github.com/modern-go",
-    "name" : "concurrent",
-    "version" : "v0.0.0-20180306012644-bacd9c7ef1dd",
-    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-    "group" : "github.com/modern-go",
-    "name" : "reflect2",
-    "version" : "v1.0.2",
-    "purl" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-    "group" : "github.com/munnerz",
-    "name" : "goautoneg",
-    "version" : "v0.0.0-20191010083416-a7dc8b61c822",
-    "purl" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-    "group" : "github.com/rogpeppe",
-    "name" : "go-internal",
-    "version" : "v1.9.0",
-    "purl" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
-    "group" : "github.com/spf13",
-    "name" : "pflag",
-    "version" : "v1.0.5",
-    "purl" : "pkg:golang/github.com/spf13/pflag@v1.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-    "group" : "golang.org/x",
-    "name" : "oauth2",
-    "version" : "v0.0.0-20220223155221-ee480838109b",
-    "purl" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/term@v0.8.0",
-    "group" : "golang.org/x",
-    "name" : "term",
-    "version" : "v0.8.0",
-    "purl" : "pkg:golang/golang.org/x/term@v0.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-    "group" : "golang.org/x",
-    "name" : "time",
-    "version" : "v0.0.0-20220210224613-90d013bbcef8",
-    "purl" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
-    "group" : "google.golang.org",
-    "name" : "protobuf",
-    "version" : "v1.30.0",
-    "purl" : "pkg:golang/google.golang.org/protobuf@v1.30.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-    "group" : "gopkg.in",
-    "name" : "inf.v0",
-    "version" : "v0.9.1",
-    "purl" : "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/api@v0.26.1",
-    "group" : "k8s.io",
-    "name" : "api",
-    "version" : "v0.26.1",
-    "purl" : "pkg:golang/k8s.io/api@v0.26.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
-    "group" : "k8s.io",
-    "name" : "apimachinery",
-    "version" : "v0.26.1",
-    "purl" : "pkg:golang/k8s.io/apimachinery@v0.26.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
-    "group" : "k8s.io",
-    "name" : "client-go",
-    "version" : "v0.26.1",
-    "purl" : "pkg:golang/k8s.io/client-go@v0.26.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-    "group" : "k8s.io",
-    "name" : "kube-openapi",
-    "version" : "v0.0.0-20221012153701-172d655c2280",
-    "purl" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-    "group" : "k8s.io",
-    "name" : "utils",
-    "version" : "v0.0.0-20221107191617-1a15be271d1d",
-    "purl" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-    "group" : "sigs.k8s.io",
-    "name" : "json",
-    "version" : "v0.0.0-20220713155537-f223a00ba0e2",
-    "purl" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-    "group" : "sigs.k8s.io/structured-merge-diff",
-    "name" : "v4",
-    "version" : "v4.2.3",
-    "purl" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-    "group" : "sigs.k8s.io",
-    "name" : "yaml",
-    "version" : "v1.3.0",
-    "purl" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "group" : "golang.org/x",
-    "name" : "xerrors",
-    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
-    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
-    "group" : "golang.org/x",
-    "name" : "crypto",
-    "version" : "v0.9.0",
-    "purl" : "pkg:golang/golang.org/x/crypto@v0.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-    "group" : "github.com/kisielk",
-    "name" : "errcheck",
-    "version" : "v1.5.0",
-    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "group" : "github.com/kisielk",
-    "name" : "gotool",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
-    "group" : "github.com/golang",
-    "name" : "mock",
-    "version" : "v1.4.4",
-    "purl" : "pkg:golang/github.com/golang/mock@v1.4.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
-    "group" : "rsc.io/quote",
-    "name" : "v3",
-    "version" : "v3.1.0",
-    "purl" : "pkg:golang/rsc.io/quote/v3@v3.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-    "group" : "golang.org/x",
-    "name" : "sync",
-    "version" : "v0.0.0-20201020160332-67f06af15bc9",
-    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-    "group" : "github.com/niemeyer",
-    "name" : "pretty",
-    "version" : "v0.0.0-20200227124842-a10e7caefd8e",
-    "purl" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-    "group" : "golang.org/x",
-    "name" : "mobile",
-    "version" : "v0.0.0-20190719004257-d2bd2a29d028",
-    "purl" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-    "group" : "github.com/armon",
-    "name" : "go-socks5",
-    "version" : "v0.0.0-20160902184237-e75332964ef5",
-    "purl" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-    "group" : "github.com/elazarl",
-    "name" : "goproxy",
-    "version" : "v0.0.0-20180725130230-947c36da3153",
-    "purl" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-    "group" : "github.com/evanphx",
-    "name" : "json-patch",
-    "version" : "v4.12.0+incompatible",
-    "purl" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
-    "group" : "github.com/moby",
-    "name" : "spdystream",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/moby/spdystream@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-    "group" : "github.com/mxk",
-    "name" : "go-flowrate",
-    "version" : "v0.0.0-20140419014527-cca7078d478f",
-    "purl" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-    "group" : "github.com/onsi/ginkgo",
-    "name" : "v2",
-    "version" : "v2.4.0",
-    "purl" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
-    "group" : "github.com/onsi",
-    "name" : "gomega",
-    "version" : "v1.23.0",
-    "purl" : "pkg:golang/github.com/onsi/gomega@v1.23.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
-    "group" : "github.com/pkg",
-    "name" : "errors",
-    "version" : "v0.9.1",
-    "purl" : "pkg:golang/github.com/pkg/errors@v0.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
-    "group" : "github.com/google/martian",
-    "name" : "v3",
-    "version" : "v3.0.0",
-    "purl" : "pkg:golang/github.com/google/martian/v3@v3.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-    "group" : "github.com/envoyproxy",
-    "name" : "go-control-plane",
-    "version" : "v0.9.4",
-    "purl" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-    "group" : "github.com/census-instrumentation",
-    "name" : "opencensus-proto",
-    "version" : "v0.2.1",
-    "purl" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-    "group" : "github.com/prometheus",
-    "name" : "client_model",
-    "version" : "v0.0.0-20190812154241-14fe0d1b01d4",
-    "purl" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-    "group" : "github.com/bytedance",
-    "name" : "sonic",
-    "version" : "v1.9.1",
-    "purl" : "pkg:golang/github.com/bytedance/sonic@v1.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "group" : "github.com/gin-contrib",
-    "name" : "sse",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-    "group" : "github.com/go-playground/validator",
-    "name" : "v10",
-    "version" : "v10.14.0",
-    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
-    "group" : "github.com/goccy",
-    "name" : "go-json",
-    "version" : "v0.10.2",
-    "purl" : "pkg:golang/github.com/goccy/go-json@v0.10.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-    "group" : "github.com/mattn",
-    "name" : "go-isatty",
-    "version" : "v0.0.19",
-    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-    "group" : "github.com/pelletier/go-toml",
-    "name" : "v2",
-    "version" : "v2.0.8",
-    "purl" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-    "group" : "github.com/ugorji/go",
-    "name" : "codec",
-    "version" : "v1.2.11",
-    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-    "group" : "github.com/chenzhuoyu",
-    "name" : "base64x",
-    "version" : "v0.0.0-20221115062448-fe3a3abad311",
-    "purl" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-    "group" : "github.com/gabriel-vasile",
-    "name" : "mimetype",
-    "version" : "v1.4.2",
-    "purl" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
-    "group" : "github.com/go-playground",
-    "name" : "locales",
-    "version" : "v0.14.1",
-    "purl" : "pkg:golang/github.com/go-playground/locales@v0.14.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-    "group" : "github.com/go-playground",
-    "name" : "universal-translator",
-    "version" : "v0.18.1",
-    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-    "group" : "github.com/klauspost/cpuid",
-    "name" : "v2",
-    "version" : "v2.2.4",
-    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-    "group" : "github.com/leodido",
-    "name" : "go-urn",
-    "version" : "v1.2.4",
-    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-    "group" : "github.com/twitchyliquid64",
-    "name" : "golang-asm",
-    "version" : "v0.15.1",
-    "purl" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
-    "group" : "golang.org/x",
-    "name" : "arch",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/golang.org/x/arch@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-    "group" : "github.com/gregjones",
-    "name" : "httpcache",
-    "version" : "v0.0.0-20180305231024-9cad4c3443a7",
-    "purl" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-    "group" : "github.com/peterbourgon",
-    "name" : "diskv",
-    "version" : "v2.0.1+incompatible",
-    "purl" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/btree@v1.0.1",
-    "group" : "github.com/google",
-    "name" : "btree",
-    "version" : "v1.0.1",
-    "purl" : "pkg:golang/github.com/google/btree@v1.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-    "group" : "gopkg.in",
-    "name" : "errgo.v2",
-    "version" : "v2.1.0",
-    "purl" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-    "group" : "github.com/pkg",
-    "name" : "diff",
-    "version" : "v0.0.0-20210226163009-20ebb0f2a09e",
-    "purl" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-    "group" : "github.com/burntsushi",
-    "name" : "toml",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/burntsushi/toml@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
-    "group" : "github.com/google",
-    "name" : "renameio",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/google/renameio@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-    "group" : "github.com/google",
-    "name" : "pprof",
-    "version" : "v0.0.0-20200708004538-1a94d8640e99",
-    "purl" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
-    "group" : "github.com/chzyer",
-    "name" : "logex",
-    "version" : "v1.1.10",
-    "purl" : "pkg:golang/github.com/chzyer/logex@v1.1.10"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-    "group" : "github.com/chzyer",
-    "name" : "readline",
-    "version" : "v0.0.0-20180603132655-2972be24d48e",
-    "purl" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-    "group" : "github.com/chzyer",
-    "name" : "test",
-    "version" : "v0.0.0-20180213035817-a1ea475d72b1",
-    "purl" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-    "group" : "github.com/ianlancetaylor",
-    "name" : "demangle",
-    "version" : "v0.0.0-20181102032728-5e5cf60278f6",
-    "purl" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-    "group" : "github.com/nytimes",
-    "name" : "gziphandler",
-    "version" : "v0.0.0-20170623195520-56545f4a5d46",
-    "purl" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-    "group" : "github.com/asaskevich",
-    "name" : "govalidator",
-    "version" : "v0.0.0-20190424111038-f61b66f89f4a",
-    "purl" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-    "group" : "github.com/mitchellh",
-    "name" : "mapstructure",
-    "version" : "v1.1.2",
-    "purl" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-    "group" : "k8s.io",
-    "name" : "gengo",
-    "version" : "v0.0.0-20210813121822-485abfe95c7c",
-    "purl" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-    "group" : "github.com/puerkitobio",
-    "name" : "purell",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-    "group" : "github.com/puerkitobio",
-    "name" : "urlesc",
-    "version" : "v0.0.0-20170810143723-de5bf2ad4578",
-    "purl" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-    "group" : "github.com/jstemmer",
-    "name" : "go-junit-report",
-    "version" : "v0.9.1",
-    "purl" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-    "group" : "cloud.google.com/go",
-    "name" : "datastore",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "group" : "github.com/kr",
-    "name" : "pty",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
-    "group" : "github.com/creack",
-    "name" : "pty",
-    "version" : "v1.1.9",
-    "purl" : "pkg:golang/github.com/creack/pty@v1.1.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-    "group" : "github.com/yuin",
-    "name" : "goldmark",
-    "version" : "v1.2.1",
-    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-    "group" : "github.com/golang",
-    "name" : "glog",
-    "version" : "v0.0.0-20160126235308-23def4e6c14b",
-    "purl" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
-    "group" : "github.com/client9",
-    "name" : "misspell",
-    "version" : "v0.3.4",
-    "purl" : "pkg:golang/github.com/client9/misspell@v0.3.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
-    "group" : "rsc.io",
-    "name" : "sampler",
-    "version" : "v1.3.0",
-    "purl" : "pkg:golang/rsc.io/sampler@v1.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-    "group" : "dmitri.shuralyov.com/gpu",
-    "name" : "mtl",
-    "version" : "v0.0.0-20190408044501-666a987793e9",
-    "purl" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-    "group" : "github.com/burntsushi",
-    "name" : "xgb",
-    "version" : "v0.0.0-20160522181843-27f122750802",
-    "purl" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-    "group" : "github.com/go-gl/glfw/v3.3",
-    "name" : "glfw",
-    "version" : "v0.0.0-20200222043503-6f7a984d4dc4",
-    "purl" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
-    "group" : "github.com/go-gl",
-    "name" : "glfw",
-    "version" : "v0.0.0-20190409004039-e6da0acd62b1",
-    "purl" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-    "group" : "github.com/google",
-    "name" : "martian",
-    "version" : "v2.1.0+incompatible",
-    "purl" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-    "group" : "rsc.io",
-    "name" : "binaryregexp",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-    "group" : "github.com/stoewer",
-    "name" : "go-strcase",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-    "group" : "github.com/docopt",
-    "name" : "docopt-go",
-    "version" : "v0.0.0-20180111231733-ee0de3bc6815",
-    "purl" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
-  } ],
-  "dependencies" : [ {
-    "ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/gin-gonic/gin@v1.9.1", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/jessevdk/go-flags@v1.5.0", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/client-go@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
-  }, {
-    "ref" : "pkg:golang/go.opencensus.io@v0.22.4",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
-    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/protobuf@v1.30.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
-    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/net@v0.10.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/term@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
-    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/client9/misspell@v0.3.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/text@v0.9.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-    "dependsOn" : [ "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
-    "dependsOn" : [ "pkg:golang/github.com/go-logr/logr@v1.2.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-logr/logr@v1.2.3",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-    "dependsOn" : [ "pkg:golang/github.com/josharian/intern@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/google.golang.org/grpc@v1.31.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b" ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible", "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/github.com/google/martian/v3@v3.0.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/rsc.io/binaryregexp@v0.2.0" ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-    "dependsOn" : [ "pkg:golang/google.golang.org/grpc@v1.31.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
-    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.2.1", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/api@v0.30.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/golang/protobuf@v1.5.2" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-    "dependsOn" : [ "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9", "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802", "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-    "dependsOn" : [ "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/google/renameio@v0.1.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-    "dependsOn" : [ "pkg:golang/github.com/bytedance/sonic@v1.9.1", "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.14.0", "pkg:golang/github.com/goccy/go-json@v0.10.2", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mattn/go-isatty@v0.0.19", "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/github.com/ugorji/go/codec@v1.2.11", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2", "pkg:golang/github.com/go-playground/locales@v0.14.1", "pkg:golang/github.com/go-playground/universal-translator@v0.18.1", "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4", "pkg:golang/github.com/leodido/go-urn@v1.2.4", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1", "pkg:golang/golang.org/x/arch@v0.3.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.5.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/stoewer/go-strcase@v1.2.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
-    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/text@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1", "pkg:golang/github.com/creack/pty@v1.1.9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-    "dependsOn" : [ "pkg:golang/gopkg.in/errgo.v2@v2.1.0", "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e" ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/term@v0.8.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/api@v0.26.1",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
-    "dependsOn" : [ "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-    "dependsOn" : [ "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46", "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/puerkitobio/purell@v1.1.1", "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/go-logr/logr@v1.2.3", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/github.com/go-logr/logr@v1.2.3" ]
-  }, {
-    "ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-    "dependsOn" : [ "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd" ]
-  }, {
-    "ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/rsc.io/quote/v3@v3.1.0" ]
-  }, {
-    "ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
-    "dependsOn" : [ "pkg:golang/rsc.io/sampler@v1.3.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-    "dependsOn" : [ "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-    "dependsOn" : [ "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/github.com/google/go-cmp@v0.5.9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/btree@v1.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
-  }, {
-    "ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-    "dependsOn" : [ "pkg:golang/github.com/chzyer/logex@v1.1.10", "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e", "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1", "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-    "dependsOn" : [ ]
-  } ]
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+      "group": "github.com/stretchr",
+      "name": "testify",
+      "version": "v1.8.3",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "group": "github.com/davecgh",
+      "name": "go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "group": "github.com/pmezard",
+      "name": "go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "group": "github.com/stretchr",
+      "name": "objx",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "version": "v2.4.0",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "group": "gopkg.in",
+      "name": "yaml.v3",
+      "version": "v3.0.1",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opencensus.io@v0.22.4",
+      "name": "go.opencensus.io",
+      "version": "v0.22.4",
+      "purl": "pkg:golang/go.opencensus.io@v0.22.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+      "group": "github.com/golang",
+      "name": "protobuf",
+      "version": "v1.5.2",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "group": "github.com/google",
+      "name": "go-cmp",
+      "version": "v0.5.9",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "group": "github.com/hashicorp",
+      "name": "golang-lru",
+      "version": "v0.5.1",
+      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0",
+      "group": "golang.org/x",
+      "name": "net",
+      "version": "v0.10.0",
+      "purl": "pkg:golang/golang.org/x/net@v0.10.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+      "group": "google.golang.org",
+      "name": "genproto",
+      "version": "v0.0.0-20201019141844-1ed22bb0c154",
+      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
+      "group": "google.golang.org",
+      "name": "grpc",
+      "version": "v1.31.0",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.31.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "group": "github.com/golang",
+      "name": "groupcache",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+      "group": "golang.org/x",
+      "name": "sys",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/sys@v0.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0",
+      "group": "golang.org/x",
+      "name": "text",
+      "version": "v0.9.0",
+      "purl": "pkg:golang/golang.org/x/text@v0.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+      "group": "github.com/go-openapi",
+      "name": "jsonreference",
+      "version": "v0.20.0",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+      "group": "github.com/go-openapi",
+      "name": "jsonpointer",
+      "version": "v0.19.5",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+      "group": "k8s.io/klog",
+      "name": "v2",
+      "version": "v2.80.1",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+      "group": "github.com/go-logr",
+      "name": "logr",
+      "version": "v1.2.3",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+      "group": "golang.org/x",
+      "name": "image",
+      "version": "v0.0.0-20190802002840-cff245a6509b",
+      "purl": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+      "group": "github.com/mailru",
+      "name": "easyjson",
+      "version": "v0.7.6",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "group": "github.com/josharian",
+      "name": "intern",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+      "group": "github.com/cncf/udpa",
+      "name": "go",
+      "version": "v0.0.0-20191209042840-269d4d468f6f",
+      "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+      "group": "github.com/envoyproxy",
+      "name": "protoc-gen-validate",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+      "group": "cloud.google.com/go",
+      "name": "bigquery",
+      "version": "v1.8.0",
+      "purl": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+      "group": "cloud.google.com",
+      "name": "go",
+      "version": "v0.65.0",
+      "purl": "pkg:golang/cloud.google.com/go@v0.65.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+      "group": "cloud.google.com/go",
+      "name": "storage",
+      "version": "v1.10.0",
+      "purl": "pkg:golang/cloud.google.com/go/storage@v1.10.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+      "group": "github.com/googleapis/gax-go",
+      "name": "v2",
+      "version": "v2.0.5",
+      "purl": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+      "group": "golang.org/x",
+      "name": "tools",
+      "version": "v0.6.0",
+      "purl": "pkg:golang/golang.org/x/tools@v0.6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/api@v0.30.0",
+      "group": "google.golang.org",
+      "name": "api",
+      "version": "v0.30.0",
+      "purl": "pkg:golang/google.golang.org/api@v0.30.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+      "group": "golang.org/x",
+      "name": "exp",
+      "version": "v0.0.0-20200224162631-6cc2880d07d6",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+      "group": "golang.org/x",
+      "name": "mod",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/mod@v0.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+      "group": "honnef.co/go",
+      "name": "tools",
+      "version": "v0.0.1-2020.1.4",
+      "purl": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+      "group": "cloud.google.com/go",
+      "name": "pubsub",
+      "version": "v1.3.1",
+      "purl": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+      "group": "google.golang.org",
+      "name": "appengine",
+      "version": "v1.6.7",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+      "group": "golang.org/x",
+      "name": "lint",
+      "version": "v0.0.0-20200302205851-738671d3881b",
+      "purl": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+      "group": "gopkg.in",
+      "name": "check.v1",
+      "version": "v1.0.0-20200227125254-8fa46927fb4f",
+      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+      "group": "github.com/emicklei/go-restful",
+      "name": "v3",
+      "version": "v3.9.0",
+      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+      "group": "github.com/gin-gonic",
+      "name": "gin",
+      "version": "v1.9.1",
+      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+      "group": "github.com/go-openapi",
+      "name": "swag",
+      "version": "v0.19.14",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "group": "github.com/gogo",
+      "name": "protobuf",
+      "version": "v1.3.2",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+      "group": "github.com/google",
+      "name": "gnostic",
+      "version": "v0.5.7-v3refs",
+      "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+      "group": "github.com/google",
+      "name": "gofuzz",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2",
+      "group": "github.com/google",
+      "name": "uuid",
+      "version": "v1.1.2",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+      "group": "github.com/imdario",
+      "name": "mergo",
+      "version": "v0.3.6",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+      "group": "github.com/jessevdk",
+      "name": "go-flags",
+      "version": "v1.5.0",
+      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "group": "github.com/json-iterator",
+      "name": "go",
+      "version": "v1.1.12",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
+      "group": "github.com/kr",
+      "name": "pretty",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/kr/pretty@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0",
+      "group": "github.com/kr",
+      "name": "text",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/kr/text@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "group": "github.com/modern-go",
+      "name": "concurrent",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "group": "github.com/modern-go",
+      "name": "reflect2",
+      "version": "v1.0.2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "group": "github.com/munnerz",
+      "name": "goautoneg",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+      "group": "github.com/rogpeppe",
+      "name": "go-internal",
+      "version": "v1.9.0",
+      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "group": "github.com/spf13",
+      "name": "pflag",
+      "version": "v1.0.5",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+      "group": "golang.org/x",
+      "name": "oauth2",
+      "version": "v0.0.0-20220223155221-ee480838109b",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0",
+      "group": "golang.org/x",
+      "name": "term",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/term@v0.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+      "group": "golang.org/x",
+      "name": "time",
+      "version": "v0.0.0-20220210224613-90d013bbcef8",
+      "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+      "group": "google.golang.org",
+      "name": "protobuf",
+      "version": "v1.30.0",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "group": "gopkg.in",
+      "name": "inf.v0",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.26.1",
+      "group": "k8s.io",
+      "name": "api",
+      "version": "v0.26.1",
+      "purl": "pkg:golang/k8s.io/api@v0.26.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
+      "group": "k8s.io",
+      "name": "apimachinery",
+      "version": "v0.26.1",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.26.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1",
+      "group": "k8s.io",
+      "name": "client-go",
+      "version": "v0.26.1",
+      "purl": "pkg:golang/k8s.io/client-go@v0.26.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+      "group": "k8s.io",
+      "name": "kube-openapi",
+      "version": "v0.0.0-20221012153701-172d655c2280",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+      "group": "k8s.io",
+      "name": "utils",
+      "version": "v0.0.0-20221107191617-1a15be271d1d",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+      "group": "sigs.k8s.io",
+      "name": "json",
+      "version": "v0.0.0-20220713155537-f223a00ba0e2",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "group": "sigs.k8s.io/structured-merge-diff",
+      "name": "v4",
+      "version": "v4.2.3",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "group": "sigs.k8s.io",
+      "name": "yaml",
+      "version": "v1.3.0",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "group": "golang.org/x",
+      "name": "xerrors",
+      "version": "v0.0.0-20200804184101-5ec99f83aff1",
+      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+      "group": "golang.org/x",
+      "name": "crypto",
+      "version": "v0.9.0",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+      "group": "github.com/kisielk",
+      "name": "errcheck",
+      "version": "v1.5.0",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "group": "github.com/kisielk",
+      "name": "gotool",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.4.4",
+      "group": "github.com/golang",
+      "name": "mock",
+      "version": "v1.4.4",
+      "purl": "pkg:golang/github.com/golang/mock@v1.4.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
+      "group": "rsc.io/quote",
+      "name": "v3",
+      "version": "v3.1.0",
+      "purl": "pkg:golang/rsc.io/quote/v3@v3.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+      "group": "golang.org/x",
+      "name": "sync",
+      "version": "v0.0.0-20201020160332-67f06af15bc9",
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+      "group": "github.com/niemeyer",
+      "name": "pretty",
+      "version": "v0.0.0-20200227124842-a10e7caefd8e",
+      "purl": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+      "group": "golang.org/x",
+      "name": "mobile",
+      "version": "v0.0.0-20190719004257-d2bd2a29d028",
+      "purl": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+      "group": "github.com/armon",
+      "name": "go-socks5",
+      "version": "v0.0.0-20160902184237-e75332964ef5",
+      "purl": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+      "group": "github.com/elazarl",
+      "name": "goproxy",
+      "version": "v0.0.0-20180725130230-947c36da3153",
+      "purl": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+      "group": "github.com/evanphx",
+      "name": "json-patch",
+      "version": "v4.12.0+incompatible",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "group": "github.com/moby",
+      "name": "spdystream",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "group": "github.com/mxk",
+      "name": "go-flowrate",
+      "version": "v0.0.0-20140419014527-cca7078d478f",
+      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+      "group": "github.com/onsi/ginkgo",
+      "name": "v2",
+      "version": "v2.4.0",
+      "purl": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
+      "group": "github.com/onsi",
+      "name": "gomega",
+      "version": "v1.23.0",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.23.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "group": "github.com/pkg",
+      "name": "errors",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
+      "group": "github.com/google/martian",
+      "name": "v3",
+      "version": "v3.0.0",
+      "purl": "pkg:golang/github.com/google/martian/v3@v3.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+      "group": "github.com/envoyproxy",
+      "name": "go-control-plane",
+      "version": "v0.9.4",
+      "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+      "group": "github.com/census-instrumentation",
+      "name": "opencensus-proto",
+      "version": "v0.2.1",
+      "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+      "group": "github.com/prometheus",
+      "name": "client_model",
+      "version": "v0.0.0-20190812154241-14fe0d1b01d4",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+      "group": "github.com/bytedance",
+      "name": "sonic",
+      "version": "v1.9.1",
+      "purl": "pkg:golang/github.com/bytedance/sonic@v1.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "group": "github.com/gin-contrib",
+      "name": "sse",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+      "group": "github.com/go-playground/validator",
+      "name": "v10",
+      "version": "v10.14.0",
+      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+      "group": "github.com/goccy",
+      "name": "go-json",
+      "version": "v0.10.2",
+      "purl": "pkg:golang/github.com/goccy/go-json@v0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+      "group": "github.com/mattn",
+      "name": "go-isatty",
+      "version": "v0.0.19",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+      "group": "github.com/pelletier/go-toml",
+      "name": "v2",
+      "version": "v2.0.8",
+      "purl": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+      "group": "github.com/ugorji/go",
+      "name": "codec",
+      "version": "v1.2.11",
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+      "group": "github.com/chenzhuoyu",
+      "name": "base64x",
+      "version": "v0.0.0-20221115062448-fe3a3abad311",
+      "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+      "group": "github.com/gabriel-vasile",
+      "name": "mimetype",
+      "version": "v1.4.2",
+      "purl": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+      "group": "github.com/go-playground",
+      "name": "locales",
+      "version": "v0.14.1",
+      "purl": "pkg:golang/github.com/go-playground/locales@v0.14.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+      "group": "github.com/go-playground",
+      "name": "universal-translator",
+      "version": "v0.18.1",
+      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+      "group": "github.com/klauspost/cpuid",
+      "name": "v2",
+      "version": "v2.2.4",
+      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+      "group": "github.com/leodido",
+      "name": "go-urn",
+      "version": "v1.2.4",
+      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+      "group": "github.com/twitchyliquid64",
+      "name": "golang-asm",
+      "version": "v0.15.1",
+      "purl": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+      "group": "golang.org/x",
+      "name": "arch",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/golang.org/x/arch@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+      "group": "github.com/gregjones",
+      "name": "httpcache",
+      "version": "v0.0.0-20180305231024-9cad4c3443a7",
+      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+      "group": "github.com/peterbourgon",
+      "name": "diskv",
+      "version": "v2.0.1+incompatible",
+      "purl": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1",
+      "group": "github.com/google",
+      "name": "btree",
+      "version": "v1.0.1",
+      "purl": "pkg:golang/github.com/google/btree@v1.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+      "group": "gopkg.in",
+      "name": "errgo.v2",
+      "version": "v2.1.0",
+      "purl": "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "group": "github.com/pkg",
+      "name": "diff",
+      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
+      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+      "group": "github.com/burntsushi",
+      "name": "toml",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/burntsushi/toml@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/renameio@v0.1.0",
+      "group": "github.com/google",
+      "name": "renameio",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/google/renameio@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+      "group": "github.com/google",
+      "name": "pprof",
+      "version": "v0.0.0-20200708004538-1a94d8640e99",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
+      "group": "github.com/chzyer",
+      "name": "logex",
+      "version": "v1.1.10",
+      "purl": "pkg:golang/github.com/chzyer/logex@v1.1.10"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+      "group": "github.com/chzyer",
+      "name": "readline",
+      "version": "v0.0.0-20180603132655-2972be24d48e",
+      "purl": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+      "group": "github.com/chzyer",
+      "name": "test",
+      "version": "v0.0.0-20180213035817-a1ea475d72b1",
+      "purl": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+      "group": "github.com/ianlancetaylor",
+      "name": "demangle",
+      "version": "v0.0.0-20181102032728-5e5cf60278f6",
+      "purl": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+      "group": "github.com/nytimes",
+      "name": "gziphandler",
+      "version": "v0.0.0-20170623195520-56545f4a5d46",
+      "purl": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+      "group": "github.com/asaskevich",
+      "name": "govalidator",
+      "version": "v0.0.0-20190424111038-f61b66f89f4a",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "group": "github.com/mitchellh",
+      "name": "mapstructure",
+      "version": "v1.1.2",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+      "group": "k8s.io",
+      "name": "gengo",
+      "version": "v0.0.0-20210813121822-485abfe95c7c",
+      "purl": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+      "group": "github.com/puerkitobio",
+      "name": "purell",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+      "group": "github.com/puerkitobio",
+      "name": "urlesc",
+      "version": "v0.0.0-20170810143723-de5bf2ad4578",
+      "purl": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+      "group": "github.com/jstemmer",
+      "name": "go-junit-report",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+      "group": "cloud.google.com/go",
+      "name": "datastore",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "group": "github.com/kr",
+      "name": "pty",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/kr/pty@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+      "group": "github.com/creack",
+      "name": "pty",
+      "version": "v1.1.9",
+      "purl": "pkg:golang/github.com/creack/pty@v1.1.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+      "group": "github.com/yuin",
+      "name": "goldmark",
+      "version": "v1.2.1",
+      "purl": "pkg:golang/github.com/yuin/goldmark@v1.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+      "group": "github.com/golang",
+      "name": "glog",
+      "version": "v0.0.0-20160126235308-23def4e6c14b",
+      "purl": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/client9/misspell@v0.3.4",
+      "group": "github.com/client9",
+      "name": "misspell",
+      "version": "v0.3.4",
+      "purl": "pkg:golang/github.com/client9/misspell@v0.3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/rsc.io/sampler@v1.3.0",
+      "group": "rsc.io",
+      "name": "sampler",
+      "version": "v1.3.0",
+      "purl": "pkg:golang/rsc.io/sampler@v1.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+      "group": "dmitri.shuralyov.com/gpu",
+      "name": "mtl",
+      "version": "v0.0.0-20190408044501-666a987793e9",
+      "purl": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+      "group": "github.com/burntsushi",
+      "name": "xgb",
+      "version": "v0.0.0-20160522181843-27f122750802",
+      "purl": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+      "group": "github.com/go-gl/glfw/v3.3",
+      "name": "glfw",
+      "version": "v0.0.0-20200222043503-6f7a984d4dc4",
+      "purl": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+      "group": "github.com/go-gl",
+      "name": "glfw",
+      "version": "v0.0.0-20190409004039-e6da0acd62b1",
+      "purl": "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+      "group": "github.com/google",
+      "name": "martian",
+      "version": "v2.1.0+incompatible",
+      "purl": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+      "group": "rsc.io",
+      "name": "binaryregexp",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+      "group": "github.com/stoewer",
+      "name": "go-strcase",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+      "group": "github.com/docopt",
+      "name": "docopt-go",
+      "version": "v0.0.0-20180111231733-ee0de3bc6815",
+      "purl": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+        "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+        "pkg:golang/github.com/go-logr/logr@v1.2.3",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/imdario/mergo@v0.3.6",
+        "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/term@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/k8s.io/api@v0.26.1",
+        "pkg:golang/k8s.io/apimachinery@v0.26.1",
+        "pkg:golang/k8s.io/client-go@v0.26.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/go.opencensus.io@v0.22.4",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+      "dependsOn": [
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/term@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
+      "dependsOn": [
+        "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+        "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@v1.4.4",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+        "pkg:golang/github.com/client9/misspell@v0.3.4",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+      "dependsOn": [
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+      "dependsOn": [
+        "pkg:golang/github.com/go-logr/logr@v1.2.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+      "dependsOn": [
+        "pkg:golang/github.com/josharian/intern@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+      "dependsOn": [
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/google.golang.org/grpc@v1.31.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/golang/mock@v1.4.4",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/github.com/google/btree@v1.0.1",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/github.com/google/martian/v3@v3.0.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+      "dependsOn": [
+        "pkg:golang/google.golang.org/grpc@v1.31.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+      "dependsOn": [
+        "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/google.golang.org/appengine@v1.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/api@v0.30.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+      "dependsOn": [
+        "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+        "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+        "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+        "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+      "dependsOn": [
+        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+        "pkg:golang/github.com/google/renameio@v0.1.0",
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+      "dependsOn": [
+        "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+        "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+        "pkg:golang/github.com/goccy/go-json@v0.10.2",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+        "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+        "pkg:golang/github.com/go-playground/locales@v0.14.1",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+        "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+        "pkg:golang/golang.org/x/arch@v0.3.0",
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": [
+        "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/pty@v1.1.1",
+        "pkg:golang/github.com/creack/pty@v1.1.9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/google.golang.org/appengine@v1.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.26.1",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/k8s.io/apimachinery@v0.26.1",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/go-logr/logr@v1.2.3",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
+      "dependsOn": [
+        "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/go-logr/logr@v1.2.3",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+        "pkg:golang/github.com/onsi/gomega@v1.23.0",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.26.1",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+        "pkg:golang/github.com/imdario/mergo@v0.3.6",
+        "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/term@v0.8.0",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/k8s.io/api@v0.26.1",
+        "pkg:golang/k8s.io/apimachinery@v0.26.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+        "pkg:golang/github.com/go-logr/logr@v1.2.3",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/google/btree@v1.0.1",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+      "dependsOn": [
+        "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+        "pkg:golang/github.com/onsi/gomega@v1.23.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+        "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/go-logr/logr@v1.2.3",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/github.com/go-logr/logr@v1.2.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+      ]
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.4.4",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/rsc.io/quote/v3@v3.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
+      "dependsOn": [
+        "pkg:golang/rsc.io/sampler@v1.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/text@v0.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.10.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+      "dependsOn": [
+        "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/renameio@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+      "dependsOn": [
+        "pkg:golang/github.com/chzyer/logex@v1.1.10",
+        "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+        "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+        "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/client9/misspell@v0.3.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/rsc.io/sampler@v1.3.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+      "dependsOn": []
+    }
+  ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_stack_analysis.json
@@ -1,289 +1,399 @@
 {
-  "bomFormat" : "CycloneDX",
-  "specVersion" : "1.4",
-  "version" : 1,
-  "metadata" : {
-    "component" : {
-      "type" : "application",
-      "bom-ref" : "pkg:golang/rhda-test@v0.0.0",
-      "name" : "rhda-test",
-      "version" : "v0.0.0",
-      "purl" : "pkg:golang/rhda-test@v0.0.0"
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/rhda-test@v0.0.0",
+      "name": "rhda-test",
+      "version": "v0.0.0",
+      "purl": "pkg:golang/rhda-test@v0.0.0"
     }
   },
-  "components" : [ {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-    "group" : "github.com/ugorji/go",
-    "name" : "codec",
-    "version" : "v1.1.7",
-    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
-    "group" : "github.com/ugorji",
-    "name" : "go",
-    "version" : "v1.1.7",
-    "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
-    "group" : "github.com/json-iterator",
-    "name" : "go",
-    "version" : "v1.1.9",
-    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "group" : "github.com/davecgh",
-    "name" : "go-spew",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
-    "group" : "github.com/google",
-    "name" : "gofuzz",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-    "group" : "github.com/modern-go",
-    "name" : "concurrent",
-    "version" : "v0.0.0-20180228061459-e0a39a4cb421",
-    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-    "group" : "github.com/modern-go",
-    "name" : "reflect2",
-    "version" : "v0.0.0-20180701023420-4b7aa43c6742",
-    "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.4.0",
-    "group" : "github.com/stretchr",
-    "name" : "testify",
-    "version" : "v1.4.0",
-    "purl" : "pkg:golang/github.com/stretchr/testify@v1.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
-    "group" : "golang.org/x",
-    "name" : "net",
-    "version" : "v0.0.0-20190404232315-eb5bcb51f2a3",
-    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-    "group" : "golang.org/x",
-    "name" : "crypto",
-    "version" : "v0.0.0-20200622213623-75b288015ac9",
-    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.2",
-    "group" : "golang.org/x",
-    "name" : "text",
-    "version" : "v0.3.2",
-    "purl" : "pkg:golang/golang.org/x/text@v0.3.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "group" : "github.com/pmezard",
-    "name" : "go-difflib",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "group" : "github.com/stretchr",
-    "name" : "objx",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-    "group" : "gopkg.in",
-    "name" : "yaml.v2",
-    "version" : "v2.2.8",
-    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
-    "group" : "github.com/emicklei/go-restful",
-    "name" : "v3",
-    "version" : "v3.0.0",
-    "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
-    "group" : "github.com/gin-gonic",
-    "name" : "gin",
-    "version" : "v1.7.7",
-    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-    "group" : "github.com/mattn",
-    "name" : "go-isatty",
-    "version" : "v0.0.12",
-    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
-    "group" : "golang.org/x",
-    "name" : "sys",
-    "version" : "v0.0.0-20200116001909-b77594299b42",
-    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
-    "group" : "github.com/go-playground/validator",
-    "name" : "v10",
-    "version" : "v10.4.1",
-    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-    "group" : "github.com/go-playground/assert",
-    "name" : "v2",
-    "version" : "v2.0.1",
-    "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
-    "group" : "github.com/go-playground",
-    "name" : "locales",
-    "version" : "v0.13.0",
-    "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-    "group" : "github.com/go-playground",
-    "name" : "universal-translator",
-    "version" : "v0.17.0",
-    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-    "group" : "github.com/leodido",
-    "name" : "go-urn",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
-    "group" : "golang.org/x",
-    "name" : "tools",
-    "version" : "v0.0.0-20180917221912-90fa682c2a6e",
-    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "group" : "github.com/gin-contrib",
-    "name" : "sse",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
-    "group" : "github.com/golang",
-    "name" : "protobuf",
-    "version" : "v1.3.3",
-    "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-    "group" : "gopkg.in",
-    "name" : "check.v1",
-    "version" : "v0.0.0-20161208181325-20d25e280405",
-    "purl" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-  } ],
-  "dependencies" : [ {
-    "ref" : "pkg:golang/rhda-test@v0.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0", "pkg:golang/github.com/gin-gonic/gin@v1.7.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/ugorji/go@v1.1.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/ugorji/go/codec@v1.1.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.0.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421", "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742", "pkg:golang/github.com/stretchr/testify@v1.4.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/testify@v1.4.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/text@v0.3.2" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42", "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/text@v0.3.2",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e" ]
-  }, {
-    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405" ]
-  }, {
-    "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
-    "dependsOn" : [ "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.4.1", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/json-iterator/go@v1.1.9", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.4.0", "pkg:golang/github.com/ugorji/go/codec@v1.1.7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
-    "dependsOn" : [ "pkg:golang/github.com/go-playground/assert/v2@v2.0.1", "pkg:golang/github.com/go-playground/locales@v0.13.0", "pkg:golang/github.com/go-playground/universal-translator@v0.17.0", "pkg:golang/github.com/leodido/go-urn@v1.2.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.3.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-playground/locales@v0.13.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.4.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.4.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-    "dependsOn" : [ ]
-  } ]
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "group": "github.com/ugorji/go",
+      "name": "codec",
+      "version": "v1.1.7",
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "group": "github.com/ugorji",
+      "name": "go",
+      "version": "v1.1.7",
+      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "group": "github.com/json-iterator",
+      "name": "go",
+      "version": "v1.1.9",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "group": "github.com/davecgh",
+      "name": "go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "group": "github.com/google",
+      "name": "gofuzz",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "group": "github.com/modern-go",
+      "name": "concurrent",
+      "version": "v0.0.0-20180228061459-e0a39a4cb421",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "group": "github.com/modern-go",
+      "name": "reflect2",
+      "version": "v0.0.0-20180701023420-4b7aa43c6742",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.4.0",
+      "group": "github.com/stretchr",
+      "name": "testify",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+      "group": "golang.org/x",
+      "name": "net",
+      "version": "v0.0.0-20190404232315-eb5bcb51f2a3",
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+      "group": "golang.org/x",
+      "name": "crypto",
+      "version": "v0.0.0-20200622213623-75b288015ac9",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.2",
+      "group": "golang.org/x",
+      "name": "text",
+      "version": "v0.3.2",
+      "purl": "pkg:golang/golang.org/x/text@v0.3.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "group": "github.com/pmezard",
+      "name": "go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "group": "github.com/stretchr",
+      "name": "objx",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "version": "v2.2.8",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+      "group": "github.com/emicklei/go-restful",
+      "name": "v3",
+      "version": "v3.0.0",
+      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+      "group": "github.com/gin-gonic",
+      "name": "gin",
+      "version": "v1.7.7",
+      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "group": "github.com/mattn",
+      "name": "go-isatty",
+      "version": "v0.0.12",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+      "group": "golang.org/x",
+      "name": "sys",
+      "version": "v0.0.0-20200116001909-b77594299b42",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+      "group": "github.com/go-playground/validator",
+      "name": "v10",
+      "version": "v10.4.1",
+      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.4.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "group": "github.com/go-playground/assert",
+      "name": "v2",
+      "version": "v2.0.1",
+      "purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "group": "github.com/go-playground",
+      "name": "locales",
+      "version": "v0.13.0",
+      "purl": "pkg:golang/github.com/go-playground/locales@v0.13.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "group": "github.com/go-playground",
+      "name": "universal-translator",
+      "version": "v0.17.0",
+      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "group": "github.com/leodido",
+      "name": "go-urn",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+      "group": "golang.org/x",
+      "name": "tools",
+      "version": "v0.0.0-20180917221912-90fa682c2a6e",
+      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "group": "github.com/gin-contrib",
+      "name": "sse",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "group": "github.com/golang",
+      "name": "protobuf",
+      "version": "v1.3.3",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "group": "gopkg.in",
+      "name": "check.v1",
+      "version": "v0.0.0-20161208181325-20d25e280405",
+      "purl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/rhda-test@v0.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+        "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.0.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+        "pkg:golang/github.com/stretchr/testify@v1.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.4.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+        "pkg:golang/golang.org/x/text@v0.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+        "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.3.2",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+      "dependsOn": [
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+        "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/json-iterator/go@v1.1.9",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/github.com/stretchr/testify@v1.4.0",
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+      "dependsOn": [
+        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+        "pkg:golang/github.com/go-playground/locales@v0.13.0",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-playground/locales@v0.13.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "dependsOn": []
+    }
+  ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_no_path/expected_sbom_stack_analysis.json
@@ -1,399 +1,289 @@
 {
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "pkg:golang/rhda-test@v0.0.0",
-      "name": "rhda-test",
-      "version": "v0.0.0",
-      "purl": "pkg:golang/rhda-test@v0.0.0"
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:golang/rhda-test@v0.0.0",
+      "name" : "rhda-test",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/rhda-test@v0.0.0"
     }
   },
-  "components": [
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
-      "group": "github.com/json-iterator",
-      "name": "go",
-      "version": "v1.1.9",
-      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "group": "github.com/davecgh",
-      "name": "go-spew",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
-      "group": "github.com/google",
-      "name": "gofuzz",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-      "group": "github.com/modern-go",
-      "name": "concurrent",
-      "version": "v0.0.0-20180228061459-e0a39a4cb421",
-      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-      "group": "github.com/modern-go",
-      "name": "reflect2",
-      "version": "v0.0.0-20180701023420-4b7aa43c6742",
-      "purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.4.0",
-      "group": "github.com/stretchr",
-      "name": "testify",
-      "version": "v1.4.0",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-      "group": "github.com/ugorji/go",
-      "name": "codec",
-      "version": "v1.1.7",
-      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
-      "group": "github.com/ugorji",
-      "name": "go",
-      "version": "v1.1.7",
-      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
-      "group": "golang.org/x",
-      "name": "net",
-      "version": "v0.0.0-20190404232315-eb5bcb51f2a3",
-      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-      "group": "golang.org/x",
-      "name": "crypto",
-      "version": "v0.0.0-20200622213623-75b288015ac9",
-      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.2",
-      "group": "golang.org/x",
-      "name": "text",
-      "version": "v0.3.2",
-      "purl": "pkg:golang/golang.org/x/text@v0.3.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "group": "github.com/pmezard",
-      "name": "go-difflib",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "group": "github.com/stretchr",
-      "name": "objx",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-      "group": "gopkg.in",
-      "name": "yaml.v2",
-      "version": "v2.2.8",
-      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
-      "group": "github.com/emicklei/go-restful",
-      "name": "v3",
-      "version": "v3.0.0",
-      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
-      "group": "github.com/gin-gonic",
-      "name": "gin",
-      "version": "v1.7.7",
-      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-      "group": "github.com/mattn",
-      "name": "go-isatty",
-      "version": "v0.0.12",
-      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
-      "group": "golang.org/x",
-      "name": "sys",
-      "version": "v0.0.0-20200116001909-b77594299b42",
-      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
-      "group": "github.com/go-playground/validator",
-      "name": "v10",
-      "version": "v10.4.1",
-      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.4.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-      "group": "github.com/go-playground/assert",
-      "name": "v2",
-      "version": "v2.0.1",
-      "purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
-      "group": "github.com/go-playground",
-      "name": "locales",
-      "version": "v0.13.0",
-      "purl": "pkg:golang/github.com/go-playground/locales@v0.13.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-      "group": "github.com/go-playground",
-      "name": "universal-translator",
-      "version": "v0.17.0",
-      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-      "group": "github.com/leodido",
-      "name": "go-urn",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
-      "group": "golang.org/x",
-      "name": "tools",
-      "version": "v0.0.0-20180917221912-90fa682c2a6e",
-      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "group": "github.com/gin-contrib",
-      "name": "sse",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
-      "group": "github.com/golang",
-      "name": "protobuf",
-      "version": "v1.3.3",
-      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-      "group": "gopkg.in",
-      "name": "check.v1",
-      "version": "v0.0.0-20161208181325-20d25e280405",
-      "purl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "pkg:golang/rhda-test@v0.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
-        "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/google/gofuzz@v1.0.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-        "pkg:golang/github.com/stretchr/testify@v1.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.4.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/stretchr/objx@v0.1.0",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/ugorji/go@v1.1.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-        "pkg:golang/golang.org/x/text@v0.3.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/text@v0.3.2",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
-      "dependsOn": [
-        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-        "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/json-iterator/go@v1.1.9",
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-        "pkg:golang/github.com/stretchr/testify@v1.4.0",
-        "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
-      "dependsOn": [
-        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-        "pkg:golang/github.com/go-playground/locales@v0.13.0",
-        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-        "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.3.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-playground/locales@v0.13.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
-      "dependsOn": []
-    }
-  ]
+  "components" : [ {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+    "group" : "github.com/ugorji/go",
+    "name" : "codec",
+    "version" : "v1.1.7",
+    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+    "group" : "github.com/ugorji",
+    "name" : "go",
+    "version" : "v1.1.7",
+    "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+    "group" : "github.com/json-iterator",
+    "name" : "go",
+    "version" : "v1.1.9",
+    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "group" : "github.com/davecgh",
+    "name" : "go-spew",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+    "group" : "github.com/google",
+    "name" : "gofuzz",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+    "group" : "github.com/modern-go",
+    "name" : "concurrent",
+    "version" : "v0.0.0-20180228061459-e0a39a4cb421",
+    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+    "group" : "github.com/modern-go",
+    "name" : "reflect2",
+    "version" : "v0.0.0-20180701023420-4b7aa43c6742",
+    "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.4.0",
+    "group" : "github.com/stretchr",
+    "name" : "testify",
+    "version" : "v1.4.0",
+    "purl" : "pkg:golang/github.com/stretchr/testify@v1.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+    "group" : "golang.org/x",
+    "name" : "net",
+    "version" : "v0.0.0-20190404232315-eb5bcb51f2a3",
+    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+    "group" : "golang.org/x",
+    "name" : "crypto",
+    "version" : "v0.0.0-20200622213623-75b288015ac9",
+    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.2",
+    "group" : "golang.org/x",
+    "name" : "text",
+    "version" : "v0.3.2",
+    "purl" : "pkg:golang/golang.org/x/text@v0.3.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "group" : "github.com/pmezard",
+    "name" : "go-difflib",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "group" : "github.com/stretchr",
+    "name" : "objx",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+    "group" : "gopkg.in",
+    "name" : "yaml.v2",
+    "version" : "v2.2.8",
+    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+    "group" : "github.com/emicklei/go-restful",
+    "name" : "v3",
+    "version" : "v3.0.0",
+    "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+    "group" : "github.com/gin-gonic",
+    "name" : "gin",
+    "version" : "v1.7.7",
+    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+    "group" : "github.com/mattn",
+    "name" : "go-isatty",
+    "version" : "v0.0.12",
+    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+    "group" : "golang.org/x",
+    "name" : "sys",
+    "version" : "v0.0.0-20200116001909-b77594299b42",
+    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+    "group" : "github.com/go-playground/validator",
+    "name" : "v10",
+    "version" : "v10.4.1",
+    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+    "group" : "github.com/go-playground/assert",
+    "name" : "v2",
+    "version" : "v2.0.1",
+    "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+    "group" : "github.com/go-playground",
+    "name" : "locales",
+    "version" : "v0.13.0",
+    "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+    "group" : "github.com/go-playground",
+    "name" : "universal-translator",
+    "version" : "v0.17.0",
+    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+    "group" : "github.com/leodido",
+    "name" : "go-urn",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+    "group" : "golang.org/x",
+    "name" : "tools",
+    "version" : "v0.0.0-20180917221912-90fa682c2a6e",
+    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "group" : "github.com/gin-contrib",
+    "name" : "sse",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+    "group" : "github.com/golang",
+    "name" : "protobuf",
+    "version" : "v1.3.3",
+    "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+    "group" : "gopkg.in",
+    "name" : "check.v1",
+    "version" : "v0.0.0-20161208181325-20d25e280405",
+    "purl" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+  } ],
+  "dependencies" : [ {
+    "ref" : "pkg:golang/rhda-test@v0.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0", "pkg:golang/github.com/gin-gonic/gin@v1.7.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/ugorji/go@v1.1.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/ugorji/go/codec@v1.1.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.0.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421", "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742", "pkg:golang/github.com/stretchr/testify@v1.4.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/testify@v1.4.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9", "pkg:golang/golang.org/x/text@v0.3.2" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42", "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/text@v0.3.2",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e" ]
+  }, {
+    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405" ]
+  }, {
+    "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.7.7",
+    "dependsOn" : [ "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.4.1", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/json-iterator/go@v1.1.9", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.4.0", "pkg:golang/github.com/ugorji/go/codec@v1.1.7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.4.1",
+    "dependsOn" : [ "pkg:golang/github.com/go-playground/assert/v2@v2.0.1", "pkg:golang/github.com/go-playground/locales@v0.13.0", "pkg:golang/github.com/go-playground/universal-translator@v0.17.0", "pkg:golang/github.com/leodido/go-urn@v1.2.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.3.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-playground/locales@v0.13.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.4.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.4.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+    "dependsOn" : [ ]
+  } ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_stack_analysis.json
@@ -1,2822 +1,1920 @@
 {
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-      "group": "github.com/devfile-samples",
-      "name": "devfile-sample-go-basic",
-      "version": "v0.0.0",
-      "purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+      "group" : "github.com/devfile-samples",
+      "name" : "devfile-sample-go-basic",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
     }
   },
-  "components": [
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-verifcid",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-      "group": "github.com/ipfs",
-      "name": "go-cid",
-      "version": "v0.0.7",
-      "purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-      "group": "github.com/multiformats",
-      "name": "go-multihash",
-      "version": "v0.0.15",
-      "purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-conn-security-multistream",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-core",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-testing",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-      "group": "github.com/multiformats",
-      "name": "go-multistream",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-discovery",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-log",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-log@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-blankhost",
-      "version": "v0.1.1",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-swarm",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-      "group": "github.com/gogo",
-      "name": "protobuf",
-      "version": "v1.3.1",
-      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-      "group": "github.com/mattn",
-      "name": "go-colorable",
-      "version": "v0.1.7",
-      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-      "group": "github.com/opentracing",
-      "name": "opentracing-go",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
-      "group": "github.com/stretchr",
-      "name": "testify",
-      "version": "v1.7.0",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.7.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-      "group": "github.com/whyrusleeping",
-      "name": "go-logging",
-      "version": "v0.0.0-20170515211332-0457bb6b88fc",
-      "purl": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-      "group": "golang.org/x",
-      "name": "net",
-      "version": "v0.0.0-20200822124328-c89045814202",
-      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
-      "group": "github.com/huin",
-      "name": "goupnp",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/huin/goupnp@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-      "group": "github.com/huin",
-      "name": "goutil",
-      "version": "v0.0.0-20170803182201-1ca381bf3150",
-      "purl": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.3",
-      "group": "golang.org/x",
-      "name": "text",
-      "version": "v0.3.3",
-      "purl": "pkg:golang/golang.org/x/text@v0.3.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-      "group": "github.com/libp2p",
-      "name": "go-yamux",
-      "version": "v1.2.2",
-      "purl": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-buffer-pool",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-      "group": "github.com/ipld",
-      "name": "go-codec-dagpb",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-      "group": "github.com/ipld",
-      "name": "go-ipld-prime",
-      "version": "v0.9.0",
-      "purl": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-      "group": "github.com/mr-tron",
-      "name": "base58",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/mr-tron/base58@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-      "group": "github.com/multiformats",
-      "name": "go-varint",
-      "version": "v0.0.6",
-      "purl": "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-      "group": "github.com/polydawn",
-      "name": "refmt",
-      "version": "v0.0.0-20201211092308-30ac6d18308e",
-      "purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "group": "golang.org/x",
-      "name": "xerrors",
-      "version": "v0.0.0-20200804184101-5ec99f83aff1",
-      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-blockservice",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-bitswap",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-      "group": "github.com/ipfs",
-      "name": "go-block-format",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-      "group": "github.com/ipfs",
-      "name": "go-datastore",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-blockstore",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-blocksutil",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-delay",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-exchange-interface",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-exchange-offline",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-routing",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-util",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "group": "github.com/gin-contrib",
-      "name": "sse",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ds-leveldb",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-      "group": "github.com/jbenet",
-      "name": "goprocess",
-      "version": "v0.1.3",
-      "purl": "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-      "group": "github.com/syndtr",
-      "name": "goleveldb",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-      "group": "github.com/leodido",
-      "name": "go-urn",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-      "group": "github.com/kisielk",
-      "name": "errcheck",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mod@v0.2.0",
-      "group": "golang.org/x",
-      "name": "mod",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/golang.org/x/mod@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-      "group": "golang.org/x",
-      "name": "crypto",
-      "version": "v0.0.0-20210220033148-5ea612d1eb83",
-      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-      "group": "golang.org/x",
-      "name": "tools",
-      "version": "v0.0.0-20200509030707-2212a7e161a5",
-      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-      "group": "github.com/btcsuite",
-      "name": "btcd",
-      "version": "v0.0.0-20190523000118-16327141da8c",
-      "purl": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-      "group": "github.com/coreos",
-      "name": "go-semver",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-flow-metrics",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-      "group": "github.com/minio",
-      "name": "sha256-simd",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-      "group": "github.com/spacemonkeygo",
-      "name": "openssl",
-      "version": "v0.0.0-20181017203307-c2dcc5cca94a",
-      "purl": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "group": "github.com/hashicorp",
-      "name": "golang-lru",
-      "version": "v0.5.1",
-      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-      "group": "github.com/ipfs",
-      "name": "bbloom",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-ds-help",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-metrics-interface",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
-      "group": "github.com/google",
-      "name": "go-cmp",
-      "version": "v0.5.4",
-      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-detect-race",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-      "group": "github.com/jbenet",
-      "name": "go-cienv",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-autonat",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-circuit",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-loggables",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-mplex",
-      "version": "v0.2.1",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-nat",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-netutil",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-peerstore",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-secio",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-transport-upgrader",
-      "version": "v0.1.1",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-yamux",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-      "group": "github.com/libp2p",
-      "name": "go-maddr-filter",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-      "group": "github.com/libp2p",
-      "name": "go-stream-muxer-multistream",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-tcp-transport",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-ws-transport",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr-dns",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr-net",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-      "group": "github.com/whyrusleeping",
-      "name": "mdns",
-      "version": "v0.0.0-20180901202407-ef14215e6b30",
-      "purl": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-      "group": "github.com/multiformats",
-      "name": "go-multibase",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-      "group": "github.com/multiformats",
-      "name": "go-base32",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
-      "group": "github.com/ugorji",
-      "name": "go",
-      "version": "v1.1.7",
-      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-      "group": "github.com/ugorji/go",
-      "name": "codec",
-      "version": "v1.1.7",
-      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-mplex",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-stream-muxer",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-      "group": "howett.net",
-      "name": "plist",
-      "version": "v0.0.0-20181124034731-591f970eefbb",
-      "purl": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-      "group": "github.com/jessevdk",
-      "name": "go-flags",
-      "version": "v1.4.0",
-      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
-      "group": "github.com/kr",
-      "name": "pretty",
-      "version": "v0.2.1",
-      "purl": "pkg:golang/github.com/kr/pretty@v0.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-      "group": "gopkg.in",
-      "name": "check.v1",
-      "version": "v1.0.0-20180628173108-788fd7840127",
-      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-      "group": "gopkg.in",
-      "name": "yaml.v2",
-      "version": "v2.2.8",
-      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-      "group": "github.com/go-playground/validator",
-      "name": "v10",
-      "version": "v10.2.0",
-      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-      "group": "github.com/go-playground/assert",
-      "name": "v2",
-      "version": "v2.0.1",
-      "purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
-      "group": "github.com/go-playground",
-      "name": "locales",
-      "version": "v0.13.0",
-      "purl": "pkg:golang/github.com/go-playground/locales@v0.13.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-      "group": "github.com/go-playground",
-      "name": "universal-translator",
-      "version": "v0.17.0",
-      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-      "group": "github.com/libp2p",
-      "name": "go-nat",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-      "group": "github.com/whyrusleeping",
-      "name": "go-notifier",
-      "version": "v0.0.0-20170827234753-097c5d47330f",
-      "purl": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-      "group": "github.com/ipfs",
-      "name": "go-ipld-cbor",
-      "version": "v0.0.5",
-      "purl": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-      "group": "github.com/ipfs",
-      "name": "go-ipld-format",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-      "group": "github.com/ipfs",
-      "name": "go-merkledag",
-      "version": "v0.3.2",
-      "purl": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-      "group": "go.elastic.co",
-      "name": "fastjson",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/go.elastic.co/fastjson@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
-      "group": "github.com/pkg",
-      "name": "errors",
-      "version": "v0.8.1",
-      "purl": "pkg:golang/github.com/pkg/errors@v0.8.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-      "group": "github.com/valyala",
-      "name": "fasttemplate",
-      "version": "v1.2.1",
-      "purl": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-      "group": "github.com/valyala",
-      "name": "bytebufferpool",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "group": "github.com/davecgh",
-      "name": "go-spew",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "group": "github.com/pmezard",
-      "name": "go-difflib",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "group": "github.com/stretchr",
-      "name": "objx",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
-      "group": "github.com/labstack",
-      "name": "gommon",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/github.com/labstack/gommon@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-      "group": "github.com/mattn",
-      "name": "go-isatty",
-      "version": "v0.0.12",
-      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-msgio",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.1",
-      "group": "github.com/google",
-      "name": "uuid",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/google/uuid@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-      "group": "golang.org/x",
-      "name": "term",
-      "version": "v0.0.0-20201117132131-f5c789dd3221",
-      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-      "group": "golang.org/x",
-      "name": "sys",
-      "version": "v0.0.0-20210309074719-68d13333faf2",
-      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-      "group": "github.com/prometheus",
-      "name": "procfs",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/prometheus/procfs@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-      "group": "golang.org/x",
-      "name": "sync",
-      "version": "v0.0.0-20190911185100-cd5d95a43a6e",
-      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-addr-util",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-      "group": "github.com/whyrusleeping",
-      "name": "mafmt",
-      "version": "v1.2.8",
-      "purl": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-      "group": "github.com/whyrusleeping",
-      "name": "multiaddr-filter",
-      "version": "v0.0.0-20160516205228-e903e4adabd7",
-      "purl": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-      "group": "github.com/klauspost/cpuid",
-      "name": "v2",
-      "version": "v2.0.4",
-      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-      "group": "github.com/gorilla",
-      "name": "websocket",
-      "version": "v1.4.0",
-      "purl": "pkg:golang/github.com/gorilla/websocket@v1.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-      "group": "github.com/elastic",
-      "name": "go-sysinfo",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-      "group": "github.com/elastic",
-      "name": "go-windows",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/elastic/go-windows@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-      "group": "github.com/joeshaw",
-      "name": "multierror",
-      "version": "v0.0.0-20140124173710-69b34d4ec901",
-      "purl": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-      "group": "github.com/minio",
-      "name": "blake2b-simd",
-      "version": "v0.0.0-20160723061019-3f5f724cb5b1",
-      "purl": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-      "group": "github.com/spaolacci",
-      "name": "murmur3",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
-      "group": "github.com/golang",
-      "name": "protobuf",
-      "version": "v1.3.3",
-      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-      "group": "google.golang.org",
-      "name": "genproto",
-      "version": "v0.0.0-20180831171423-11092d34479b",
-      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-      "group": "github.com/ipfs",
-      "name": "go-ds-badger",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-crypto",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-peer",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-      "group": "github.com/whyrusleeping",
-      "name": "go-keyspace",
-      "version": "v0.0.0-20160322163242-5b898ac5add1",
-      "purl": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-record",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-      "group": "github.com/andreasbriese",
-      "name": "bbloom",
-      "version": "v0.0.0-20180913140656-343706a395b7",
-      "purl": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-      "group": "github.com/kubuxu",
-      "name": "go-os-helper",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-      "group": "github.com/dgraph-io",
-      "name": "badger",
-      "version": "v1.5.5-0.20190226225317-8115aed38f8f",
-      "purl": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-      "group": "github.com/dgryski",
-      "name": "go-farm",
-      "version": "v0.0.0-20190104051053-3adb47b1fb0f",
-      "purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-      "group": "github.com/dustin",
-      "name": "go-humanize",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-      "group": "github.com/spacemonkeygo",
-      "name": "spacelog",
-      "version": "v0.0.0-20180420211403-2296661a0572",
-      "purl": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-reuseport",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-reuseport-transport",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr-fmt",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-      "group": "github.com/go-check",
-      "name": "check",
-      "version": "v0.0.0-20180628173108-788fd7840127",
-      "purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-      "group": "github.com/frankban",
-      "name": "quicktest",
-      "version": "v1.11.3",
-      "purl": "pkg:golang/github.com/frankban/quicktest@v1.11.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-      "group": "github.com/smartystreets",
-      "name": "goconvey",
-      "version": "v1.6.4",
-      "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-      "group": "github.com/warpfork",
-      "name": "go-wish",
-      "version": "v0.0.0-20200122115046-b9ea61034e4a",
-      "purl": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/text@v0.1.0",
-      "group": "github.com/kr",
-      "name": "text",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/kr/text@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
-      "group": "github.com/aead",
-      "name": "siphash",
-      "version": "v1.0.1",
-      "purl": "pkg:golang/github.com/aead/siphash@v1.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-      "group": "github.com/btcsuite",
-      "name": "btclog",
-      "version": "v0.0.0-20170628155309-84c8d2346e9f",
-      "purl": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-      "group": "github.com/btcsuite",
-      "name": "btcutil",
-      "version": "v0.0.0-20190425235716-9e5f4b9a998d",
-      "purl": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-      "group": "github.com/btcsuite",
-      "name": "go-socks",
-      "version": "v0.0.0-20170105172521-4720035b7bfd",
-      "purl": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-      "group": "github.com/btcsuite",
-      "name": "goleveldb",
-      "version": "v0.0.0-20160330041536-7834afc9e8cd",
-      "purl": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-      "group": "github.com/btcsuite",
-      "name": "snappy-go",
-      "version": "v0.0.0-20151229074030-0bdef8d06723",
-      "purl": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-      "group": "github.com/btcsuite",
-      "name": "websocket",
-      "version": "v0.0.0-20150119174127-31079b680792",
-      "purl": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-      "group": "github.com/btcsuite",
-      "name": "winsvc",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-      "group": "github.com/jrick",
-      "name": "logrotate",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/jrick/logrotate@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-      "group": "github.com/kkdai",
-      "name": "bstream",
-      "version": "v0.0.0-20161212061736-f391b8402d23",
-      "purl": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-      "group": "github.com/onsi",
-      "name": "ginkgo",
-      "version": "v1.8.0",
-      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
-      "group": "github.com/onsi",
-      "name": "gomega",
-      "version": "v1.5.0",
-      "purl": "pkg:golang/github.com/onsi/gomega@v1.5.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
-      "group": "github.com/kr",
-      "name": "pty",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/kr/pty@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-      "group": "github.com/jbenet",
-      "name": "go-temp-err-catcher",
-      "version": "v0.0.0-20150120210811-aac704a3f4f2",
-      "purl": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
-      "group": "github.com/armon",
-      "name": "go-radix",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/armon/go-radix@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
-      "group": "github.com/cucumber",
-      "name": "godog",
-      "version": "v0.8.1",
-      "purl": "pkg:golang/github.com/cucumber/godog@v0.8.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-      "group": "github.com/santhosh-tekuri",
-      "name": "jsonschema",
-      "version": "v1.2.4",
-      "purl": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-      "group": "github.com/whyrusleeping",
-      "name": "cbor-gen",
-      "version": "v0.0.0-20200123233031-1cdf64d27158",
-      "purl": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
-      "group": "github.com/beevik",
-      "name": "etree",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/beevik/etree@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-      "group": "github.com/jonboulle",
-      "name": "clockwork",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-      "group": "github.com/fsnotify",
-      "name": "fsnotify",
-      "version": "v1.4.7",
-      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-      "group": "github.com/hpcloud",
-      "name": "tail",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-      "group": "gopkg.in",
-      "name": "fsnotify.v1",
-      "version": "v1.4.7",
-      "purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-      "group": "gopkg.in",
-      "name": "tomb.v1",
-      "version": "v1.0.0-20141024135613-dd632973f1e7",
-      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
-      "group": "github.com/json-iterator",
-      "name": "go",
-      "version": "v1.1.9",
-      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
-      "group": "github.com/google",
-      "name": "gofuzz",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-      "group": "github.com/modern-go",
-      "name": "concurrent",
-      "version": "v0.0.0-20180228061459-e0a39a4cb421",
-      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-      "group": "github.com/modern-go",
-      "name": "reflect2",
-      "version": "v0.0.0-20180701023420-4b7aa43c6742",
-      "purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-      "group": "github.com/gopherjs",
-      "name": "gopherjs",
-      "version": "v0.0.0-20181017120253-0766667cb4d1",
-      "purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-      "group": "github.com/jtolds",
-      "name": "gls",
-      "version": "v4.20.0+incompatible",
-      "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-      "group": "github.com/smartystreets",
-      "name": "assertions",
-      "version": "v0.0.0-20180927180507-b2de0cb4f26d",
-      "purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-      "group": "github.com/golang",
-      "name": "snappy",
-      "version": "v0.0.0-20180518054509-2e65f85255db",
-      "purl": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-      "group": "github.com/cskr",
-      "name": "pubsub",
-      "version": "v1.0.2",
-      "purl": "pkg:golang/github.com/cskr/pubsub@v1.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-peertaskqueue",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-testutil",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-      "group": "github.com/jackpal",
-      "name": "gateway",
-      "version": "v1.0.5",
-      "purl": "pkg:golang/github.com/jackpal/gateway@v1.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-      "group": "github.com/jackpal",
-      "name": "go-nat-pmp",
-      "version": "v1.0.1",
-      "purl": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-      "group": "github.com/koron",
-      "name": "go-ssdp",
-      "version": "v0.0.0-20180514024734-4a0ed625a78b",
-      "purl": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-      "group": "github.com/dgrijalva",
-      "name": "jwt-go",
-      "version": "v3.2.0+incompatible",
-      "purl": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-pq",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-      "dependsOn": [ ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-      "dependsOn": [
-        "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-        "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-        "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-        "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-      "dependsOn": [
-        "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/stretchr/objx@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/text@v0.3.3",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-      "dependsOn": [
-        "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/google/uuid@v1.1.1",
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-      "dependsOn": [
-        "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-        "pkg:golang/github.com/google/uuid@v1.1.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/kr/pretty@v0.2.1",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-      "dependsOn": [
-        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/github.com/onsi/gomega@v1.5.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mod@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-      "dependsOn": [
-        "pkg:golang/github.com/aead/siphash@v1.0.1",
-        "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-        "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-        "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-        "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-        "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-        "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-        "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-        "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-        "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/github.com/onsi/gomega@v1.5.0",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-      "dependsOn": [
-        "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-        "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/google/uuid@v1.1.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-        "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-        "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/github.com/onsi/gomega@v1.5.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/ugorji/go@v1.1.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-      "dependsOn": [
-        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-        "pkg:golang/github.com/kr/pretty@v0.2.1",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/text@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-        "pkg:golang/github.com/go-playground/locales@v0.13.0",
-        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-        "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-playground/locales@v0.13.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/huin/goupnp@v1.0.0",
-        "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-        "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-        "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-      "dependsOn": [
-        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
-      "dependsOn": [
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/uuid@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-      "dependsOn": [
-        "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-        "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-        "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-        "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-        "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-        "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/pkg/errors@v0.8.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/github.com/kr/pretty@v0.2.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-      "dependsOn": [
-        "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-        "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-        "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/text@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/pty@v1.1.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
-      "dependsOn": [
-        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3",
-        "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/pty@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/google/gofuzz@v1.0.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-      "dependsOn": []
-    }
-  ]
+  "components" : [ {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-verifcid",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+    "group" : "github.com/ipfs",
+    "name" : "go-cid",
+    "version" : "v0.0.7",
+    "purl" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+    "group" : "github.com/multiformats",
+    "name" : "go-multihash",
+    "version" : "v0.0.15",
+    "purl" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-conn-security-multistream",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-core",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-testing",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+    "group" : "github.com/multiformats",
+    "name" : "go-multistream",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-discovery",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-log",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-log@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-blankhost",
+    "version" : "v0.1.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-swarm",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+    "group" : "github.com/gogo",
+    "name" : "protobuf",
+    "version" : "v1.3.1",
+    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+    "group" : "github.com/mattn",
+    "name" : "go-colorable",
+    "version" : "v0.1.7",
+    "purl" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+    "group" : "github.com/opentracing",
+    "name" : "opentracing-go",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
+    "group" : "github.com/stretchr",
+    "name" : "testify",
+    "version" : "v1.7.0",
+    "purl" : "pkg:golang/github.com/stretchr/testify@v1.7.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+    "group" : "github.com/whyrusleeping",
+    "name" : "go-logging",
+    "version" : "v0.0.0-20170515211332-0457bb6b88fc",
+    "purl" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+    "group" : "golang.org/x",
+    "name" : "net",
+    "version" : "v0.0.0-20200822124328-c89045814202",
+    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
+    "group" : "github.com/huin",
+    "name" : "goupnp",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/huin/goupnp@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+    "group" : "github.com/huin",
+    "name" : "goutil",
+    "version" : "v0.0.0-20170803182201-1ca381bf3150",
+    "purl" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.3",
+    "group" : "golang.org/x",
+    "name" : "text",
+    "version" : "v0.3.3",
+    "purl" : "pkg:golang/golang.org/x/text@v0.3.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-yamux",
+    "version" : "v1.2.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-buffer-pool",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+    "group" : "github.com/ipld",
+    "name" : "go-codec-dagpb",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+    "group" : "github.com/ipld",
+    "name" : "go-ipld-prime",
+    "version" : "v0.9.0",
+    "purl" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+    "group" : "github.com/mr-tron",
+    "name" : "base58",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/mr-tron/base58@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+    "group" : "github.com/multiformats",
+    "name" : "go-varint",
+    "version" : "v0.0.6",
+    "purl" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+    "group" : "github.com/polydawn",
+    "name" : "refmt",
+    "version" : "v0.0.0-20201211092308-30ac6d18308e",
+    "purl" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "group" : "golang.org/x",
+    "name" : "xerrors",
+    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
+    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-blockservice",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-bitswap",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+    "group" : "github.com/ipfs",
+    "name" : "go-block-format",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-datastore",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-blockstore",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-blocksutil",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-delay",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-exchange-interface",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-exchange-offline",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-routing",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-util",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "group" : "github.com/gin-contrib",
+    "name" : "sse",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ds-leveldb",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+    "group" : "github.com/jbenet",
+    "name" : "goprocess",
+    "version" : "v0.1.3",
+    "purl" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+    "group" : "github.com/syndtr",
+    "name" : "goleveldb",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+    "group" : "github.com/leodido",
+    "name" : "go-urn",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
+    "group" : "golang.org/x",
+    "name" : "mod",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/golang.org/x/mod@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+    "group" : "golang.org/x",
+    "name" : "crypto",
+    "version" : "v0.0.0-20210220033148-5ea612d1eb83",
+    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+    "group" : "golang.org/x",
+    "name" : "tools",
+    "version" : "v0.0.0-20200509030707-2212a7e161a5",
+    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+    "group" : "github.com/kisielk",
+    "name" : "errcheck",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "group" : "github.com/kisielk",
+    "name" : "gotool",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-detect-race",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+    "group" : "github.com/jbenet",
+    "name" : "go-cienv",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-autonat",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-circuit",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-loggables",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-mplex",
+    "version" : "v0.2.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-nat",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-netutil",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-peerstore",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-secio",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-transport-upgrader",
+    "version" : "v0.1.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-yamux",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+    "group" : "github.com/libp2p",
+    "name" : "go-maddr-filter",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-stream-muxer-multistream",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-tcp-transport",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-ws-transport",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr-dns",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr-net",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+    "group" : "github.com/whyrusleeping",
+    "name" : "mdns",
+    "version" : "v0.0.0-20180901202407-ef14215e6b30",
+    "purl" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
+    "group" : "github.com/google",
+    "name" : "go-cmp",
+    "version" : "v0.5.4",
+    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "group" : "github.com/hashicorp",
+    "name" : "golang-lru",
+    "version" : "v0.5.1",
+    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+    "group" : "github.com/ipfs",
+    "name" : "bbloom",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-ds-help",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-metrics-interface",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+    "group" : "github.com/btcsuite",
+    "name" : "btcd",
+    "version" : "v0.0.0-20190523000118-16327141da8c",
+    "purl" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+    "group" : "github.com/coreos",
+    "name" : "go-semver",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/github.com/coreos/go-semver@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-flow-metrics",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+    "group" : "github.com/minio",
+    "name" : "sha256-simd",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+    "group" : "github.com/spacemonkeygo",
+    "name" : "openssl",
+    "version" : "v0.0.0-20181017203307-c2dcc5cca94a",
+    "purl" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+    "group" : "github.com/multiformats",
+    "name" : "go-multibase",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+    "group" : "github.com/multiformats",
+    "name" : "go-base32",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+    "group" : "github.com/multiformats",
+    "name" : "go-base36",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+    "group" : "github.com/ugorji",
+    "name" : "go",
+    "version" : "v1.1.7",
+    "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+    "group" : "github.com/ugorji/go",
+    "name" : "codec",
+    "version" : "v1.1.7",
+    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-mplex",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-stream-muxer",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+    "group" : "howett.net",
+    "name" : "plist",
+    "version" : "v0.0.0-20181124034731-591f970eefbb",
+    "purl" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+    "group" : "github.com/jessevdk",
+    "name" : "go-flags",
+    "version" : "v1.4.0",
+    "purl" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
+    "group" : "github.com/kr",
+    "name" : "pretty",
+    "version" : "v0.2.1",
+    "purl" : "pkg:golang/github.com/kr/pretty@v0.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+    "group" : "gopkg.in",
+    "name" : "check.v1",
+    "version" : "v1.0.0-20180628173108-788fd7840127",
+    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+    "group" : "gopkg.in",
+    "name" : "yaml.v2",
+    "version" : "v2.2.8",
+    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+    "group" : "github.com/go-playground/validator",
+    "name" : "v10",
+    "version" : "v10.2.0",
+    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+    "group" : "github.com/go-playground/assert",
+    "name" : "v2",
+    "version" : "v2.0.1",
+    "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+    "group" : "github.com/go-playground",
+    "name" : "locales",
+    "version" : "v0.13.0",
+    "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+    "group" : "github.com/go-playground",
+    "name" : "universal-translator",
+    "version" : "v0.17.0",
+    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+    "group" : "github.com/libp2p",
+    "name" : "go-nat",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+    "group" : "github.com/whyrusleeping",
+    "name" : "go-notifier",
+    "version" : "v0.0.0-20170827234753-097c5d47330f",
+    "purl" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipld-cbor",
+    "version" : "v0.0.5",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipld-format",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+    "group" : "github.com/ipfs",
+    "name" : "go-merkledag",
+    "version" : "v0.3.2",
+    "purl" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+    "group" : "go.elastic.co",
+    "name" : "fastjson",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/go.elastic.co/fastjson@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
+    "group" : "github.com/pkg",
+    "name" : "errors",
+    "version" : "v0.8.1",
+    "purl" : "pkg:golang/github.com/pkg/errors@v0.8.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+    "group" : "github.com/valyala",
+    "name" : "fasttemplate",
+    "version" : "v1.2.1",
+    "purl" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+    "group" : "github.com/valyala",
+    "name" : "bytebufferpool",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
+    "group" : "github.com/labstack",
+    "name" : "gommon",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/github.com/labstack/gommon@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+    "group" : "github.com/mattn",
+    "name" : "go-isatty",
+    "version" : "v0.0.12",
+    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "group" : "github.com/davecgh",
+    "name" : "go-spew",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "group" : "github.com/pmezard",
+    "name" : "go-difflib",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "group" : "github.com/stretchr",
+    "name" : "objx",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-msgio",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
+    "group" : "github.com/google",
+    "name" : "uuid",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/google/uuid@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+    "group" : "golang.org/x",
+    "name" : "term",
+    "version" : "v0.0.0-20201117132131-f5c789dd3221",
+    "purl" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+    "group" : "golang.org/x",
+    "name" : "sys",
+    "version" : "v0.0.0-20210309074719-68d13333faf2",
+    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-addr-util",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+    "group" : "github.com/whyrusleeping",
+    "name" : "mafmt",
+    "version" : "v1.2.8",
+    "purl" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+    "group" : "github.com/whyrusleeping",
+    "name" : "multiaddr-filter",
+    "version" : "v0.0.0-20160516205228-e903e4adabd7",
+    "purl" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+    "group" : "github.com/prometheus",
+    "name" : "procfs",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/prometheus/procfs@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+    "group" : "golang.org/x",
+    "name" : "sync",
+    "version" : "v0.0.0-20190911185100-cd5d95a43a6e",
+    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+    "group" : "github.com/klauspost/cpuid",
+    "name" : "v2",
+    "version" : "v2.0.4",
+    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+    "group" : "github.com/gorilla",
+    "name" : "websocket",
+    "version" : "v1.4.0",
+    "purl" : "pkg:golang/github.com/gorilla/websocket@v1.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+    "group" : "github.com/elastic",
+    "name" : "go-sysinfo",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+    "group" : "github.com/elastic",
+    "name" : "go-windows",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/elastic/go-windows@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+    "group" : "github.com/joeshaw",
+    "name" : "multierror",
+    "version" : "v0.0.0-20140124173710-69b34d4ec901",
+    "purl" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+    "group" : "github.com/gxed/hashland",
+    "name" : "keccakpg",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+    "group" : "github.com/gxed/hashland",
+    "name" : "murmur3",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+    "group" : "github.com/minio",
+    "name" : "blake2b-simd",
+    "version" : "v0.0.0-20160723061019-3f5f724cb5b1",
+    "purl" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+    "group" : "github.com/spaolacci",
+    "name" : "murmur3",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+    "group" : "github.com/golang",
+    "name" : "protobuf",
+    "version" : "v1.3.3",
+    "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+    "group" : "google.golang.org",
+    "name" : "genproto",
+    "version" : "v0.0.0-20180831171423-11092d34479b",
+    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+    "group" : "github.com/ipfs",
+    "name" : "go-ds-badger",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-crypto",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-peer",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+    "group" : "github.com/whyrusleeping",
+    "name" : "go-keyspace",
+    "version" : "v0.0.0-20160322163242-5b898ac5add1",
+    "purl" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-record",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+    "group" : "github.com/andreasbriese",
+    "name" : "bbloom",
+    "version" : "v0.0.0-20180913140656-343706a395b7",
+    "purl" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+    "group" : "github.com/kubuxu",
+    "name" : "go-os-helper",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+    "group" : "github.com/dgraph-io",
+    "name" : "badger",
+    "version" : "v1.5.5-0.20190226225317-8115aed38f8f",
+    "purl" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+    "group" : "github.com/dgryski",
+    "name" : "go-farm",
+    "version" : "v0.0.0-20190104051053-3adb47b1fb0f",
+    "purl" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+    "group" : "github.com/dustin",
+    "name" : "go-humanize",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+    "group" : "github.com/spacemonkeygo",
+    "name" : "spacelog",
+    "version" : "v0.0.0-20180420211403-2296661a0572",
+    "purl" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-reuseport",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-reuseport-transport",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr-fmt",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+    "group" : "github.com/frankban",
+    "name" : "quicktest",
+    "version" : "v1.11.3",
+    "purl" : "pkg:golang/github.com/frankban/quicktest@v1.11.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+    "group" : "github.com/go-check",
+    "name" : "check",
+    "version" : "v0.0.0-20180628173108-788fd7840127",
+    "purl" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+    "group" : "github.com/smartystreets",
+    "name" : "goconvey",
+    "version" : "v1.6.4",
+    "purl" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+    "group" : "github.com/warpfork",
+    "name" : "go-wish",
+    "version" : "v0.0.0-20200122115046-b9ea61034e4a",
+    "purl" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+    "group" : "github.com/whyrusleeping",
+    "name" : "cbor-gen",
+    "version" : "v0.0.0-20200123233031-1cdf64d27158",
+    "purl" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/text@v0.1.0",
+    "group" : "github.com/kr",
+    "name" : "text",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/kr/text@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
+    "group" : "github.com/aead",
+    "name" : "siphash",
+    "version" : "v1.0.1",
+    "purl" : "pkg:golang/github.com/aead/siphash@v1.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+    "group" : "github.com/btcsuite",
+    "name" : "btclog",
+    "version" : "v0.0.0-20170628155309-84c8d2346e9f",
+    "purl" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+    "group" : "github.com/btcsuite",
+    "name" : "btcutil",
+    "version" : "v0.0.0-20190425235716-9e5f4b9a998d",
+    "purl" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+    "group" : "github.com/btcsuite",
+    "name" : "go-socks",
+    "version" : "v0.0.0-20170105172521-4720035b7bfd",
+    "purl" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+    "group" : "github.com/btcsuite",
+    "name" : "goleveldb",
+    "version" : "v0.0.0-20160330041536-7834afc9e8cd",
+    "purl" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+    "group" : "github.com/btcsuite",
+    "name" : "snappy-go",
+    "version" : "v0.0.0-20151229074030-0bdef8d06723",
+    "purl" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+    "group" : "github.com/btcsuite",
+    "name" : "websocket",
+    "version" : "v0.0.0-20150119174127-31079b680792",
+    "purl" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+    "group" : "github.com/btcsuite",
+    "name" : "winsvc",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+    "group" : "github.com/jrick",
+    "name" : "logrotate",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/jrick/logrotate@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+    "group" : "github.com/kkdai",
+    "name" : "bstream",
+    "version" : "v0.0.0-20161212061736-f391b8402d23",
+    "purl" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+    "group" : "github.com/onsi",
+    "name" : "ginkgo",
+    "version" : "v1.8.0",
+    "purl" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
+    "group" : "github.com/onsi",
+    "name" : "gomega",
+    "version" : "v1.5.0",
+    "purl" : "pkg:golang/github.com/onsi/gomega@v1.5.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "group" : "github.com/kr",
+    "name" : "pty",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+    "group" : "github.com/jbenet",
+    "name" : "go-temp-err-catcher",
+    "version" : "v0.0.0-20150120210811-aac704a3f4f2",
+    "purl" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
+    "group" : "github.com/armon",
+    "name" : "go-radix",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/armon/go-radix@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
+    "group" : "github.com/cucumber",
+    "name" : "godog",
+    "version" : "v0.8.1",
+    "purl" : "pkg:golang/github.com/cucumber/godog@v0.8.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+    "group" : "github.com/santhosh-tekuri",
+    "name" : "jsonschema",
+    "version" : "v1.2.4",
+    "purl" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+    "group" : "github.com/yuin",
+    "name" : "goldmark",
+    "version" : "v1.1.27",
+    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.1.27"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
+    "group" : "github.com/beevik",
+    "name" : "etree",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/beevik/etree@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+    "group" : "github.com/jonboulle",
+    "name" : "clockwork",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+    "group" : "github.com/fsnotify",
+    "name" : "fsnotify",
+    "version" : "v1.4.7",
+    "purl" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+    "group" : "github.com/hpcloud",
+    "name" : "tail",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/hpcloud/tail@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+    "group" : "gopkg.in",
+    "name" : "fsnotify.v1",
+    "version" : "v1.4.7",
+    "purl" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+    "group" : "gopkg.in",
+    "name" : "tomb.v1",
+    "version" : "v1.0.0-20141024135613-dd632973f1e7",
+    "purl" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+    "group" : "github.com/json-iterator",
+    "name" : "go",
+    "version" : "v1.1.9",
+    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+    "group" : "github.com/google",
+    "name" : "gofuzz",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+    "group" : "github.com/modern-go",
+    "name" : "concurrent",
+    "version" : "v0.0.0-20180228061459-e0a39a4cb421",
+    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+    "group" : "github.com/modern-go",
+    "name" : "reflect2",
+    "version" : "v0.0.0-20180701023420-4b7aa43c6742",
+    "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+    "group" : "github.com/gopherjs",
+    "name" : "gopherjs",
+    "version" : "v0.0.0-20181017120253-0766667cb4d1",
+    "purl" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+    "group" : "github.com/jtolds",
+    "name" : "gls",
+    "version" : "v4.20.0+incompatible",
+    "purl" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+    "group" : "github.com/smartystreets",
+    "name" : "assertions",
+    "version" : "v0.0.0-20180927180507-b2de0cb4f26d",
+    "purl" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+    "group" : "github.com/golang",
+    "name" : "snappy",
+    "version" : "v0.0.0-20180518054509-2e65f85255db",
+    "purl" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+    "group" : "github.com/cskr",
+    "name" : "pubsub",
+    "version" : "v1.0.2",
+    "purl" : "pkg:golang/github.com/cskr/pubsub@v1.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-peertaskqueue",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-testutil",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+    "group" : "github.com/jackpal",
+    "name" : "gateway",
+    "version" : "v1.0.5",
+    "purl" : "pkg:golang/github.com/jackpal/gateway@v1.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+    "group" : "github.com/jackpal",
+    "name" : "go-nat-pmp",
+    "version" : "v1.0.1",
+    "purl" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+    "group" : "github.com/koron",
+    "name" : "go-ssdp",
+    "version" : "v0.0.0-20180514024734-4a0ed625a78b",
+    "purl" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+    "group" : "github.com/dgrijalva",
+    "name" : "jwt-go",
+    "version" : "v3.2.0+incompatible",
+    "purl" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-pq",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
+  } ],
+  "dependencies" : [ {
+    "ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multibase@v0.0.3", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+    "dependsOn" : [ "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1", "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1", "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/github.com/spaolacci/murmur3@v1.1.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c", "pkg:golang/github.com/coreos/go-semver@v0.3.0", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8", "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.2.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/text@v0.3.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+    "dependsOn" : [ "pkg:golang/github.com/frankban/quicktest@v1.11.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/cskr/pubsub@v1.0.2", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-testutil@v0.1.0", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+    "dependsOn" : [ "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/bbloom@v0.0.4", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/syndtr/goleveldb@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+    "dependsOn" : [ "pkg:golang/github.com/jbenet/go-cienv@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.1.27", "pkg:golang/golang.org/x/mod@v0.2.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0", "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-mplex@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-nat@v0.0.3", "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2", "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-msgio@v0.0.2", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-yamux@v1.2.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gorilla/websocket@v1.4.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
+    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/multiformats/go-base32@v0.0.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+    "dependsOn" : [ "pkg:golang/github.com/aead/siphash@v1.0.1", "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f", "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d", "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd", "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd", "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723", "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792", "pkg:golang/github.com/btcsuite/winsvc@v1.0.0", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/jrick/logrotate@v1.0.0", "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
+  }, {
+    "ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+    "dependsOn" : [ "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-base36@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/ugorji/go/codec@v1.1.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/ugorji/go@v1.1.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+    "dependsOn" : [ "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
+    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-playground/assert/v2@v2.0.1", "pkg:golang/github.com/go-playground/locales@v0.13.0", "pkg:golang/github.com/go-playground/universal-translator@v0.17.0", "pkg:golang/github.com/leodido/go-urn@v1.2.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-playground/locales@v0.13.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/huin/goupnp@v1.0.0", "pkg:golang/github.com/jackpal/gateway@v1.0.5", "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1", "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a", "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+    "dependsOn" : [ "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
+    "dependsOn" : [ "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/valyala/fasttemplate@v1.2.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/github.com/google/go-cmp@v0.5.4" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+    "dependsOn" : [ "pkg:golang/github.com/elastic/go-windows@v1.0.0", "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/prometheus/procfs@v0.0.3", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb" ]
+  }, {
+    "ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7", "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1", "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f", "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f", "pkg:golang/github.com/dustin/go-humanize@v1.0.0", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/pkg/errors@v0.8.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/kr/pretty@v0.2.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+    "dependsOn" : [ "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1", "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible", "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/text@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
+    "dependsOn" : [ "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/hpcloud/tail@v1.0.0", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7", "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.0.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421", "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+    "dependsOn" : [ ]
+  } ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_stack_analysis.json
@@ -1,1920 +1,2896 @@
 {
-  "bomFormat" : "CycloneDX",
-  "specVersion" : "1.4",
-  "version" : 1,
-  "metadata" : {
-    "component" : {
-      "type" : "application",
-      "bom-ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-      "group" : "github.com/devfile-samples",
-      "name" : "devfile-sample-go-basic",
-      "version" : "v0.0.0",
-      "purl" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+      "group": "github.com/devfile-samples",
+      "name": "devfile-sample-go-basic",
+      "version": "v0.0.0",
+      "purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
     }
   },
-  "components" : [ {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-verifcid",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-    "group" : "github.com/ipfs",
-    "name" : "go-cid",
-    "version" : "v0.0.7",
-    "purl" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-    "group" : "github.com/multiformats",
-    "name" : "go-multihash",
-    "version" : "v0.0.15",
-    "purl" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-conn-security-multistream",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-core",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-testing",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-    "group" : "github.com/multiformats",
-    "name" : "go-multistream",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-discovery",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-log",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-log@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-blankhost",
-    "version" : "v0.1.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-swarm",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-    "group" : "github.com/gogo",
-    "name" : "protobuf",
-    "version" : "v1.3.1",
-    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-    "group" : "github.com/mattn",
-    "name" : "go-colorable",
-    "version" : "v0.1.7",
-    "purl" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-    "group" : "github.com/opentracing",
-    "name" : "opentracing-go",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
-    "group" : "github.com/stretchr",
-    "name" : "testify",
-    "version" : "v1.7.0",
-    "purl" : "pkg:golang/github.com/stretchr/testify@v1.7.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-    "group" : "github.com/whyrusleeping",
-    "name" : "go-logging",
-    "version" : "v0.0.0-20170515211332-0457bb6b88fc",
-    "purl" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-    "group" : "golang.org/x",
-    "name" : "net",
-    "version" : "v0.0.0-20200822124328-c89045814202",
-    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
-    "group" : "github.com/huin",
-    "name" : "goupnp",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/huin/goupnp@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-    "group" : "github.com/huin",
-    "name" : "goutil",
-    "version" : "v0.0.0-20170803182201-1ca381bf3150",
-    "purl" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.3",
-    "group" : "golang.org/x",
-    "name" : "text",
-    "version" : "v0.3.3",
-    "purl" : "pkg:golang/golang.org/x/text@v0.3.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-yamux",
-    "version" : "v1.2.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-buffer-pool",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-    "group" : "github.com/ipld",
-    "name" : "go-codec-dagpb",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-    "group" : "github.com/ipld",
-    "name" : "go-ipld-prime",
-    "version" : "v0.9.0",
-    "purl" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-    "group" : "github.com/mr-tron",
-    "name" : "base58",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/mr-tron/base58@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-    "group" : "github.com/multiformats",
-    "name" : "go-varint",
-    "version" : "v0.0.6",
-    "purl" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-    "group" : "github.com/polydawn",
-    "name" : "refmt",
-    "version" : "v0.0.0-20201211092308-30ac6d18308e",
-    "purl" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "group" : "golang.org/x",
-    "name" : "xerrors",
-    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
-    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-blockservice",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-bitswap",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-    "group" : "github.com/ipfs",
-    "name" : "go-block-format",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-datastore",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-blockstore",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-blocksutil",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-delay",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-exchange-interface",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-exchange-offline",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-routing",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-util",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "group" : "github.com/gin-contrib",
-    "name" : "sse",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ds-leveldb",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-    "group" : "github.com/jbenet",
-    "name" : "goprocess",
-    "version" : "v0.1.3",
-    "purl" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-    "group" : "github.com/syndtr",
-    "name" : "goleveldb",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-    "group" : "github.com/leodido",
-    "name" : "go-urn",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
-    "group" : "golang.org/x",
-    "name" : "mod",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/golang.org/x/mod@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-    "group" : "golang.org/x",
-    "name" : "crypto",
-    "version" : "v0.0.0-20210220033148-5ea612d1eb83",
-    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-    "group" : "golang.org/x",
-    "name" : "tools",
-    "version" : "v0.0.0-20200509030707-2212a7e161a5",
-    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-    "group" : "github.com/kisielk",
-    "name" : "errcheck",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "group" : "github.com/kisielk",
-    "name" : "gotool",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-detect-race",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-    "group" : "github.com/jbenet",
-    "name" : "go-cienv",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-autonat",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-circuit",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-loggables",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-mplex",
-    "version" : "v0.2.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-nat",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-netutil",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-peerstore",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-secio",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-transport-upgrader",
-    "version" : "v0.1.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-yamux",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-    "group" : "github.com/libp2p",
-    "name" : "go-maddr-filter",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-stream-muxer-multistream",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-tcp-transport",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-ws-transport",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr-dns",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr-net",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-    "group" : "github.com/whyrusleeping",
-    "name" : "mdns",
-    "version" : "v0.0.0-20180901202407-ef14215e6b30",
-    "purl" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
-    "group" : "github.com/google",
-    "name" : "go-cmp",
-    "version" : "v0.5.4",
-    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "group" : "github.com/hashicorp",
-    "name" : "golang-lru",
-    "version" : "v0.5.1",
-    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-    "group" : "github.com/ipfs",
-    "name" : "bbloom",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-ds-help",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-metrics-interface",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-    "group" : "github.com/btcsuite",
-    "name" : "btcd",
-    "version" : "v0.0.0-20190523000118-16327141da8c",
-    "purl" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-    "group" : "github.com/coreos",
-    "name" : "go-semver",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/github.com/coreos/go-semver@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-flow-metrics",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-    "group" : "github.com/minio",
-    "name" : "sha256-simd",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-    "group" : "github.com/spacemonkeygo",
-    "name" : "openssl",
-    "version" : "v0.0.0-20181017203307-c2dcc5cca94a",
-    "purl" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-    "group" : "github.com/multiformats",
-    "name" : "go-multibase",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-    "group" : "github.com/multiformats",
-    "name" : "go-base32",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
-    "group" : "github.com/multiformats",
-    "name" : "go-base36",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
-    "group" : "github.com/ugorji",
-    "name" : "go",
-    "version" : "v1.1.7",
-    "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-    "group" : "github.com/ugorji/go",
-    "name" : "codec",
-    "version" : "v1.1.7",
-    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-mplex",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-stream-muxer",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-    "group" : "howett.net",
-    "name" : "plist",
-    "version" : "v0.0.0-20181124034731-591f970eefbb",
-    "purl" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-    "group" : "github.com/jessevdk",
-    "name" : "go-flags",
-    "version" : "v1.4.0",
-    "purl" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
-    "group" : "github.com/kr",
-    "name" : "pretty",
-    "version" : "v0.2.1",
-    "purl" : "pkg:golang/github.com/kr/pretty@v0.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-    "group" : "gopkg.in",
-    "name" : "check.v1",
-    "version" : "v1.0.0-20180628173108-788fd7840127",
-    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-    "group" : "gopkg.in",
-    "name" : "yaml.v2",
-    "version" : "v2.2.8",
-    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-    "group" : "github.com/go-playground/validator",
-    "name" : "v10",
-    "version" : "v10.2.0",
-    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-    "group" : "github.com/go-playground/assert",
-    "name" : "v2",
-    "version" : "v2.0.1",
-    "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
-    "group" : "github.com/go-playground",
-    "name" : "locales",
-    "version" : "v0.13.0",
-    "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-    "group" : "github.com/go-playground",
-    "name" : "universal-translator",
-    "version" : "v0.17.0",
-    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-    "group" : "github.com/libp2p",
-    "name" : "go-nat",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-    "group" : "github.com/whyrusleeping",
-    "name" : "go-notifier",
-    "version" : "v0.0.0-20170827234753-097c5d47330f",
-    "purl" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipld-cbor",
-    "version" : "v0.0.5",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipld-format",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-    "group" : "github.com/ipfs",
-    "name" : "go-merkledag",
-    "version" : "v0.3.2",
-    "purl" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-    "group" : "go.elastic.co",
-    "name" : "fastjson",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/go.elastic.co/fastjson@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
-    "group" : "github.com/pkg",
-    "name" : "errors",
-    "version" : "v0.8.1",
-    "purl" : "pkg:golang/github.com/pkg/errors@v0.8.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-    "group" : "github.com/valyala",
-    "name" : "fasttemplate",
-    "version" : "v1.2.1",
-    "purl" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-    "group" : "github.com/valyala",
-    "name" : "bytebufferpool",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
-    "group" : "github.com/labstack",
-    "name" : "gommon",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/github.com/labstack/gommon@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-    "group" : "github.com/mattn",
-    "name" : "go-isatty",
-    "version" : "v0.0.12",
-    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "group" : "github.com/davecgh",
-    "name" : "go-spew",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "group" : "github.com/pmezard",
-    "name" : "go-difflib",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "group" : "github.com/stretchr",
-    "name" : "objx",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-msgio",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
-    "group" : "github.com/google",
-    "name" : "uuid",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/google/uuid@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-    "group" : "golang.org/x",
-    "name" : "term",
-    "version" : "v0.0.0-20201117132131-f5c789dd3221",
-    "purl" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-    "group" : "golang.org/x",
-    "name" : "sys",
-    "version" : "v0.0.0-20210309074719-68d13333faf2",
-    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-addr-util",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-    "group" : "github.com/whyrusleeping",
-    "name" : "mafmt",
-    "version" : "v1.2.8",
-    "purl" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-    "group" : "github.com/whyrusleeping",
-    "name" : "multiaddr-filter",
-    "version" : "v0.0.0-20160516205228-e903e4adabd7",
-    "purl" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-    "group" : "github.com/prometheus",
-    "name" : "procfs",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/prometheus/procfs@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-    "group" : "golang.org/x",
-    "name" : "sync",
-    "version" : "v0.0.0-20190911185100-cd5d95a43a6e",
-    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-    "group" : "github.com/klauspost/cpuid",
-    "name" : "v2",
-    "version" : "v2.0.4",
-    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-    "group" : "github.com/gorilla",
-    "name" : "websocket",
-    "version" : "v1.4.0",
-    "purl" : "pkg:golang/github.com/gorilla/websocket@v1.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-    "group" : "github.com/elastic",
-    "name" : "go-sysinfo",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-    "group" : "github.com/elastic",
-    "name" : "go-windows",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/elastic/go-windows@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-    "group" : "github.com/joeshaw",
-    "name" : "multierror",
-    "version" : "v0.0.0-20140124173710-69b34d4ec901",
-    "purl" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
-    "group" : "github.com/gxed/hashland",
-    "name" : "keccakpg",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
-    "group" : "github.com/gxed/hashland",
-    "name" : "murmur3",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-    "group" : "github.com/minio",
-    "name" : "blake2b-simd",
-    "version" : "v0.0.0-20160723061019-3f5f724cb5b1",
-    "purl" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-    "group" : "github.com/spaolacci",
-    "name" : "murmur3",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
-    "group" : "github.com/golang",
-    "name" : "protobuf",
-    "version" : "v1.3.3",
-    "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-    "group" : "google.golang.org",
-    "name" : "genproto",
-    "version" : "v0.0.0-20180831171423-11092d34479b",
-    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-    "group" : "github.com/ipfs",
-    "name" : "go-ds-badger",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-crypto",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-peer",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-    "group" : "github.com/whyrusleeping",
-    "name" : "go-keyspace",
-    "version" : "v0.0.0-20160322163242-5b898ac5add1",
-    "purl" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-record",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-    "group" : "github.com/andreasbriese",
-    "name" : "bbloom",
-    "version" : "v0.0.0-20180913140656-343706a395b7",
-    "purl" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-    "group" : "github.com/kubuxu",
-    "name" : "go-os-helper",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-    "group" : "github.com/dgraph-io",
-    "name" : "badger",
-    "version" : "v1.5.5-0.20190226225317-8115aed38f8f",
-    "purl" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-    "group" : "github.com/dgryski",
-    "name" : "go-farm",
-    "version" : "v0.0.0-20190104051053-3adb47b1fb0f",
-    "purl" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-    "group" : "github.com/dustin",
-    "name" : "go-humanize",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-    "group" : "github.com/spacemonkeygo",
-    "name" : "spacelog",
-    "version" : "v0.0.0-20180420211403-2296661a0572",
-    "purl" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-reuseport",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-reuseport-transport",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr-fmt",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-    "group" : "github.com/frankban",
-    "name" : "quicktest",
-    "version" : "v1.11.3",
-    "purl" : "pkg:golang/github.com/frankban/quicktest@v1.11.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-    "group" : "github.com/go-check",
-    "name" : "check",
-    "version" : "v0.0.0-20180628173108-788fd7840127",
-    "purl" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-    "group" : "github.com/smartystreets",
-    "name" : "goconvey",
-    "version" : "v1.6.4",
-    "purl" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-    "group" : "github.com/warpfork",
-    "name" : "go-wish",
-    "version" : "v0.0.0-20200122115046-b9ea61034e4a",
-    "purl" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-    "group" : "github.com/whyrusleeping",
-    "name" : "cbor-gen",
-    "version" : "v0.0.0-20200123233031-1cdf64d27158",
-    "purl" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/text@v0.1.0",
-    "group" : "github.com/kr",
-    "name" : "text",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/kr/text@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
-    "group" : "github.com/aead",
-    "name" : "siphash",
-    "version" : "v1.0.1",
-    "purl" : "pkg:golang/github.com/aead/siphash@v1.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-    "group" : "github.com/btcsuite",
-    "name" : "btclog",
-    "version" : "v0.0.0-20170628155309-84c8d2346e9f",
-    "purl" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-    "group" : "github.com/btcsuite",
-    "name" : "btcutil",
-    "version" : "v0.0.0-20190425235716-9e5f4b9a998d",
-    "purl" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-    "group" : "github.com/btcsuite",
-    "name" : "go-socks",
-    "version" : "v0.0.0-20170105172521-4720035b7bfd",
-    "purl" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-    "group" : "github.com/btcsuite",
-    "name" : "goleveldb",
-    "version" : "v0.0.0-20160330041536-7834afc9e8cd",
-    "purl" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-    "group" : "github.com/btcsuite",
-    "name" : "snappy-go",
-    "version" : "v0.0.0-20151229074030-0bdef8d06723",
-    "purl" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-    "group" : "github.com/btcsuite",
-    "name" : "websocket",
-    "version" : "v0.0.0-20150119174127-31079b680792",
-    "purl" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-    "group" : "github.com/btcsuite",
-    "name" : "winsvc",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-    "group" : "github.com/jrick",
-    "name" : "logrotate",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/jrick/logrotate@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-    "group" : "github.com/kkdai",
-    "name" : "bstream",
-    "version" : "v0.0.0-20161212061736-f391b8402d23",
-    "purl" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-    "group" : "github.com/onsi",
-    "name" : "ginkgo",
-    "version" : "v1.8.0",
-    "purl" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
-    "group" : "github.com/onsi",
-    "name" : "gomega",
-    "version" : "v1.5.0",
-    "purl" : "pkg:golang/github.com/onsi/gomega@v1.5.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "group" : "github.com/kr",
-    "name" : "pty",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-    "group" : "github.com/jbenet",
-    "name" : "go-temp-err-catcher",
-    "version" : "v0.0.0-20150120210811-aac704a3f4f2",
-    "purl" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
-    "group" : "github.com/armon",
-    "name" : "go-radix",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/armon/go-radix@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
-    "group" : "github.com/cucumber",
-    "name" : "godog",
-    "version" : "v0.8.1",
-    "purl" : "pkg:golang/github.com/cucumber/godog@v0.8.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-    "group" : "github.com/santhosh-tekuri",
-    "name" : "jsonschema",
-    "version" : "v1.2.4",
-    "purl" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
-    "group" : "github.com/yuin",
-    "name" : "goldmark",
-    "version" : "v1.1.27",
-    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.1.27"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
-    "group" : "github.com/beevik",
-    "name" : "etree",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/beevik/etree@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-    "group" : "github.com/jonboulle",
-    "name" : "clockwork",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-    "group" : "github.com/fsnotify",
-    "name" : "fsnotify",
-    "version" : "v1.4.7",
-    "purl" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-    "group" : "github.com/hpcloud",
-    "name" : "tail",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/hpcloud/tail@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-    "group" : "gopkg.in",
-    "name" : "fsnotify.v1",
-    "version" : "v1.4.7",
-    "purl" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-    "group" : "gopkg.in",
-    "name" : "tomb.v1",
-    "version" : "v1.0.0-20141024135613-dd632973f1e7",
-    "purl" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
-    "group" : "github.com/json-iterator",
-    "name" : "go",
-    "version" : "v1.1.9",
-    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
-    "group" : "github.com/google",
-    "name" : "gofuzz",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-    "group" : "github.com/modern-go",
-    "name" : "concurrent",
-    "version" : "v0.0.0-20180228061459-e0a39a4cb421",
-    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-    "group" : "github.com/modern-go",
-    "name" : "reflect2",
-    "version" : "v0.0.0-20180701023420-4b7aa43c6742",
-    "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-    "group" : "github.com/gopherjs",
-    "name" : "gopherjs",
-    "version" : "v0.0.0-20181017120253-0766667cb4d1",
-    "purl" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-    "group" : "github.com/jtolds",
-    "name" : "gls",
-    "version" : "v4.20.0+incompatible",
-    "purl" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-    "group" : "github.com/smartystreets",
-    "name" : "assertions",
-    "version" : "v0.0.0-20180927180507-b2de0cb4f26d",
-    "purl" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-    "group" : "github.com/golang",
-    "name" : "snappy",
-    "version" : "v0.0.0-20180518054509-2e65f85255db",
-    "purl" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-    "group" : "github.com/cskr",
-    "name" : "pubsub",
-    "version" : "v1.0.2",
-    "purl" : "pkg:golang/github.com/cskr/pubsub@v1.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-peertaskqueue",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-testutil",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-    "group" : "github.com/jackpal",
-    "name" : "gateway",
-    "version" : "v1.0.5",
-    "purl" : "pkg:golang/github.com/jackpal/gateway@v1.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-    "group" : "github.com/jackpal",
-    "name" : "go-nat-pmp",
-    "version" : "v1.0.1",
-    "purl" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-    "group" : "github.com/koron",
-    "name" : "go-ssdp",
-    "version" : "v0.0.0-20180514024734-4a0ed625a78b",
-    "purl" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-    "group" : "github.com/dgrijalva",
-    "name" : "jwt-go",
-    "version" : "v3.2.0+incompatible",
-    "purl" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-pq",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
-  } ],
-  "dependencies" : [ {
-    "ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multibase@v0.0.3", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-    "dependsOn" : [ "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1", "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1", "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/github.com/spaolacci/murmur3@v1.1.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c", "pkg:golang/github.com/coreos/go-semver@v0.3.0", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8", "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.2.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/text@v0.3.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-    "dependsOn" : [ "pkg:golang/github.com/frankban/quicktest@v1.11.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/cskr/pubsub@v1.0.2", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-testutil@v0.1.0", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-    "dependsOn" : [ "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/bbloom@v0.0.4", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/syndtr/goleveldb@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-    "dependsOn" : [ "pkg:golang/github.com/jbenet/go-cienv@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.1.27", "pkg:golang/golang.org/x/mod@v0.2.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0", "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-mplex@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-nat@v0.0.3", "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2", "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-msgio@v0.0.2", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-yamux@v1.2.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gorilla/websocket@v1.4.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
-    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/multiformats/go-base32@v0.0.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-    "dependsOn" : [ "pkg:golang/github.com/aead/siphash@v1.0.1", "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f", "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d", "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd", "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd", "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723", "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792", "pkg:golang/github.com/btcsuite/winsvc@v1.0.0", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/jrick/logrotate@v1.0.0", "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
-  }, {
-    "ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-    "dependsOn" : [ "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-base36@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/ugorji/go/codec@v1.1.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/ugorji/go@v1.1.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-    "dependsOn" : [ "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
-    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-playground/assert/v2@v2.0.1", "pkg:golang/github.com/go-playground/locales@v0.13.0", "pkg:golang/github.com/go-playground/universal-translator@v0.17.0", "pkg:golang/github.com/leodido/go-urn@v1.2.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-playground/locales@v0.13.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/huin/goupnp@v1.0.0", "pkg:golang/github.com/jackpal/gateway@v1.0.5", "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1", "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a", "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-    "dependsOn" : [ "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
-    "dependsOn" : [ "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/valyala/fasttemplate@v1.2.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/github.com/google/go-cmp@v0.5.4" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-    "dependsOn" : [ "pkg:golang/github.com/elastic/go-windows@v1.0.0", "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/prometheus/procfs@v0.0.3", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb" ]
-  }, {
-    "ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7", "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1", "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f", "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f", "pkg:golang/github.com/dustin/go-humanize@v1.0.0", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/pkg/errors@v0.8.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/kr/pretty@v0.2.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-    "dependsOn" : [ "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1", "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible", "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/text@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
-    "dependsOn" : [ "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/hpcloud/tail@v1.0.0", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7", "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.0.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421", "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-    "dependsOn" : [ ]
-  } ]
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-verifcid",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+      "group": "github.com/ipfs",
+      "name": "go-cid",
+      "version": "v0.0.7",
+      "purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+      "group": "github.com/multiformats",
+      "name": "go-multihash",
+      "version": "v0.0.15",
+      "purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-conn-security-multistream",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-core",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-testing",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+      "group": "github.com/multiformats",
+      "name": "go-multistream",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-discovery",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-log",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-log@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-blankhost",
+      "version": "v0.1.1",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-swarm",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+      "group": "github.com/gogo",
+      "name": "protobuf",
+      "version": "v1.3.1",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+      "group": "github.com/mattn",
+      "name": "go-colorable",
+      "version": "v0.1.7",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+      "group": "github.com/opentracing",
+      "name": "opentracing-go",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+      "group": "github.com/stretchr",
+      "name": "testify",
+      "version": "v1.7.0",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.7.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+      "group": "github.com/whyrusleeping",
+      "name": "go-logging",
+      "version": "v0.0.0-20170515211332-0457bb6b88fc",
+      "purl": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+      "group": "golang.org/x",
+      "name": "net",
+      "version": "v0.0.0-20200822124328-c89045814202",
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
+      "group": "github.com/huin",
+      "name": "goupnp",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/huin/goupnp@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+      "group": "github.com/huin",
+      "name": "goutil",
+      "version": "v0.0.0-20170803182201-1ca381bf3150",
+      "purl": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.3",
+      "group": "golang.org/x",
+      "name": "text",
+      "version": "v0.3.3",
+      "purl": "pkg:golang/golang.org/x/text@v0.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+      "group": "github.com/libp2p",
+      "name": "go-yamux",
+      "version": "v1.2.2",
+      "purl": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-buffer-pool",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+      "group": "github.com/ipld",
+      "name": "go-codec-dagpb",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+      "group": "github.com/ipld",
+      "name": "go-ipld-prime",
+      "version": "v0.9.0",
+      "purl": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+      "group": "github.com/mr-tron",
+      "name": "base58",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/mr-tron/base58@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+      "group": "github.com/multiformats",
+      "name": "go-varint",
+      "version": "v0.0.6",
+      "purl": "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+      "group": "github.com/polydawn",
+      "name": "refmt",
+      "version": "v0.0.0-20201211092308-30ac6d18308e",
+      "purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "group": "golang.org/x",
+      "name": "xerrors",
+      "version": "v0.0.0-20200804184101-5ec99f83aff1",
+      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-blockservice",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-bitswap",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+      "group": "github.com/ipfs",
+      "name": "go-block-format",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+      "group": "github.com/ipfs",
+      "name": "go-datastore",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-blockstore",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-blocksutil",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-delay",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-exchange-interface",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-exchange-offline",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-routing",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-util",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "group": "github.com/gin-contrib",
+      "name": "sse",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ds-leveldb",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+      "group": "github.com/jbenet",
+      "name": "goprocess",
+      "version": "v0.1.3",
+      "purl": "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+      "group": "github.com/syndtr",
+      "name": "goleveldb",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "group": "github.com/leodido",
+      "name": "go-urn",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.2.0",
+      "group": "golang.org/x",
+      "name": "mod",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/golang.org/x/mod@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+      "group": "golang.org/x",
+      "name": "crypto",
+      "version": "v0.0.0-20210220033148-5ea612d1eb83",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+      "group": "golang.org/x",
+      "name": "tools",
+      "version": "v0.0.0-20200509030707-2212a7e161a5",
+      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+      "group": "github.com/kisielk",
+      "name": "errcheck",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "group": "github.com/kisielk",
+      "name": "gotool",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-detect-race",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+      "group": "github.com/jbenet",
+      "name": "go-cienv",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-autonat",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-circuit",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-loggables",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-mplex",
+      "version": "v0.2.1",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-nat",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-netutil",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-peerstore",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-secio",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-transport-upgrader",
+      "version": "v0.1.1",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-yamux",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+      "group": "github.com/libp2p",
+      "name": "go-maddr-filter",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+      "group": "github.com/libp2p",
+      "name": "go-stream-muxer-multistream",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-tcp-transport",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-ws-transport",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr-dns",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr-net",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+      "group": "github.com/whyrusleeping",
+      "name": "mdns",
+      "version": "v0.0.0-20180901202407-ef14215e6b30",
+      "purl": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
+      "group": "github.com/google",
+      "name": "go-cmp",
+      "version": "v0.5.4",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "group": "github.com/hashicorp",
+      "name": "golang-lru",
+      "version": "v0.5.1",
+      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+      "group": "github.com/ipfs",
+      "name": "bbloom",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-ds-help",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-metrics-interface",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+      "group": "github.com/btcsuite",
+      "name": "btcd",
+      "version": "v0.0.0-20190523000118-16327141da8c",
+      "purl": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+      "group": "github.com/coreos",
+      "name": "go-semver",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-flow-metrics",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+      "group": "github.com/minio",
+      "name": "sha256-simd",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+      "group": "github.com/spacemonkeygo",
+      "name": "openssl",
+      "version": "v0.0.0-20181017203307-c2dcc5cca94a",
+      "purl": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+      "group": "github.com/multiformats",
+      "name": "go-multibase",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+      "group": "github.com/multiformats",
+      "name": "go-base32",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+      "group": "github.com/multiformats",
+      "name": "go-base36",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "group": "github.com/ugorji",
+      "name": "go",
+      "version": "v1.1.7",
+      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "group": "github.com/ugorji/go",
+      "name": "codec",
+      "version": "v1.1.7",
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-mplex",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-stream-muxer",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+      "group": "howett.net",
+      "name": "plist",
+      "version": "v0.0.0-20181124034731-591f970eefbb",
+      "purl": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+      "group": "github.com/jessevdk",
+      "name": "go-flags",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
+      "group": "github.com/kr",
+      "name": "pretty",
+      "version": "v0.2.1",
+      "purl": "pkg:golang/github.com/kr/pretty@v0.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+      "group": "gopkg.in",
+      "name": "check.v1",
+      "version": "v1.0.0-20180628173108-788fd7840127",
+      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "version": "v2.2.8",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+      "group": "github.com/go-playground/validator",
+      "name": "v10",
+      "version": "v10.2.0",
+      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "group": "github.com/go-playground/assert",
+      "name": "v2",
+      "version": "v2.0.1",
+      "purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "group": "github.com/go-playground",
+      "name": "locales",
+      "version": "v0.13.0",
+      "purl": "pkg:golang/github.com/go-playground/locales@v0.13.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "group": "github.com/go-playground",
+      "name": "universal-translator",
+      "version": "v0.17.0",
+      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+      "group": "github.com/libp2p",
+      "name": "go-nat",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+      "group": "github.com/whyrusleeping",
+      "name": "go-notifier",
+      "version": "v0.0.0-20170827234753-097c5d47330f",
+      "purl": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+      "group": "github.com/ipfs",
+      "name": "go-ipld-cbor",
+      "version": "v0.0.5",
+      "purl": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+      "group": "github.com/ipfs",
+      "name": "go-ipld-format",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+      "group": "github.com/ipfs",
+      "name": "go-merkledag",
+      "version": "v0.3.2",
+      "purl": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+      "group": "go.elastic.co",
+      "name": "fastjson",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/go.elastic.co/fastjson@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
+      "group": "github.com/pkg",
+      "name": "errors",
+      "version": "v0.8.1",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.8.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+      "group": "github.com/valyala",
+      "name": "fasttemplate",
+      "version": "v1.2.1",
+      "purl": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+      "group": "github.com/valyala",
+      "name": "bytebufferpool",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "group": "github.com/labstack",
+      "name": "gommon",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/github.com/labstack/gommon@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "group": "github.com/mattn",
+      "name": "go-isatty",
+      "version": "v0.0.12",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "group": "github.com/davecgh",
+      "name": "go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "group": "github.com/pmezard",
+      "name": "go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "group": "github.com/stretchr",
+      "name": "objx",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-msgio",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.1",
+      "group": "github.com/google",
+      "name": "uuid",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+      "group": "golang.org/x",
+      "name": "term",
+      "version": "v0.0.0-20201117132131-f5c789dd3221",
+      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+      "group": "golang.org/x",
+      "name": "sys",
+      "version": "v0.0.0-20210309074719-68d13333faf2",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-addr-util",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+      "group": "github.com/whyrusleeping",
+      "name": "mafmt",
+      "version": "v1.2.8",
+      "purl": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+      "group": "github.com/whyrusleeping",
+      "name": "multiaddr-filter",
+      "version": "v0.0.0-20160516205228-e903e4adabd7",
+      "purl": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+      "group": "github.com/prometheus",
+      "name": "procfs",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+      "group": "golang.org/x",
+      "name": "sync",
+      "version": "v0.0.0-20190911185100-cd5d95a43a6e",
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+      "group": "github.com/klauspost/cpuid",
+      "name": "v2",
+      "version": "v2.0.4",
+      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+      "group": "github.com/gorilla",
+      "name": "websocket",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+      "group": "github.com/elastic",
+      "name": "go-sysinfo",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+      "group": "github.com/elastic",
+      "name": "go-windows",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/elastic/go-windows@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+      "group": "github.com/joeshaw",
+      "name": "multierror",
+      "version": "v0.0.0-20140124173710-69b34d4ec901",
+      "purl": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+      "group": "github.com/gxed/hashland",
+      "name": "keccakpg",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+      "group": "github.com/gxed/hashland",
+      "name": "murmur3",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+      "group": "github.com/minio",
+      "name": "blake2b-simd",
+      "version": "v0.0.0-20160723061019-3f5f724cb5b1",
+      "purl": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+      "group": "github.com/spaolacci",
+      "name": "murmur3",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "group": "github.com/golang",
+      "name": "protobuf",
+      "version": "v1.3.3",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+      "group": "google.golang.org",
+      "name": "genproto",
+      "version": "v0.0.0-20180831171423-11092d34479b",
+      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+      "group": "github.com/ipfs",
+      "name": "go-ds-badger",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-crypto",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-peer",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+      "group": "github.com/whyrusleeping",
+      "name": "go-keyspace",
+      "version": "v0.0.0-20160322163242-5b898ac5add1",
+      "purl": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-record",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+      "group": "github.com/andreasbriese",
+      "name": "bbloom",
+      "version": "v0.0.0-20180913140656-343706a395b7",
+      "purl": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+      "group": "github.com/kubuxu",
+      "name": "go-os-helper",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+      "group": "github.com/dgraph-io",
+      "name": "badger",
+      "version": "v1.5.5-0.20190226225317-8115aed38f8f",
+      "purl": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+      "group": "github.com/dgryski",
+      "name": "go-farm",
+      "version": "v0.0.0-20190104051053-3adb47b1fb0f",
+      "purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+      "group": "github.com/dustin",
+      "name": "go-humanize",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+      "group": "github.com/spacemonkeygo",
+      "name": "spacelog",
+      "version": "v0.0.0-20180420211403-2296661a0572",
+      "purl": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-reuseport",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-reuseport-transport",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr-fmt",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+      "group": "github.com/frankban",
+      "name": "quicktest",
+      "version": "v1.11.3",
+      "purl": "pkg:golang/github.com/frankban/quicktest@v1.11.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+      "group": "github.com/go-check",
+      "name": "check",
+      "version": "v0.0.0-20180628173108-788fd7840127",
+      "purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "group": "github.com/smartystreets",
+      "name": "goconvey",
+      "version": "v1.6.4",
+      "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+      "group": "github.com/warpfork",
+      "name": "go-wish",
+      "version": "v0.0.0-20200122115046-b9ea61034e4a",
+      "purl": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+      "group": "github.com/whyrusleeping",
+      "name": "cbor-gen",
+      "version": "v0.0.0-20200123233031-1cdf64d27158",
+      "purl": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/text@v0.1.0",
+      "group": "github.com/kr",
+      "name": "text",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/kr/text@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
+      "group": "github.com/aead",
+      "name": "siphash",
+      "version": "v1.0.1",
+      "purl": "pkg:golang/github.com/aead/siphash@v1.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+      "group": "github.com/btcsuite",
+      "name": "btclog",
+      "version": "v0.0.0-20170628155309-84c8d2346e9f",
+      "purl": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+      "group": "github.com/btcsuite",
+      "name": "btcutil",
+      "version": "v0.0.0-20190425235716-9e5f4b9a998d",
+      "purl": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+      "group": "github.com/btcsuite",
+      "name": "go-socks",
+      "version": "v0.0.0-20170105172521-4720035b7bfd",
+      "purl": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+      "group": "github.com/btcsuite",
+      "name": "goleveldb",
+      "version": "v0.0.0-20160330041536-7834afc9e8cd",
+      "purl": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+      "group": "github.com/btcsuite",
+      "name": "snappy-go",
+      "version": "v0.0.0-20151229074030-0bdef8d06723",
+      "purl": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+      "group": "github.com/btcsuite",
+      "name": "websocket",
+      "version": "v0.0.0-20150119174127-31079b680792",
+      "purl": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+      "group": "github.com/btcsuite",
+      "name": "winsvc",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+      "group": "github.com/jrick",
+      "name": "logrotate",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/jrick/logrotate@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+      "group": "github.com/kkdai",
+      "name": "bstream",
+      "version": "v0.0.0-20161212061736-f391b8402d23",
+      "purl": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+      "group": "github.com/onsi",
+      "name": "ginkgo",
+      "version": "v1.8.0",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
+      "group": "github.com/onsi",
+      "name": "gomega",
+      "version": "v1.5.0",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.5.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "group": "github.com/kr",
+      "name": "pty",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/kr/pty@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+      "group": "github.com/jbenet",
+      "name": "go-temp-err-catcher",
+      "version": "v0.0.0-20150120210811-aac704a3f4f2",
+      "purl": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
+      "group": "github.com/armon",
+      "name": "go-radix",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/armon/go-radix@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+      "group": "github.com/cucumber",
+      "name": "godog",
+      "version": "v0.8.1",
+      "purl": "pkg:golang/github.com/cucumber/godog@v0.8.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+      "group": "github.com/santhosh-tekuri",
+      "name": "jsonschema",
+      "version": "v1.2.4",
+      "purl": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+      "group": "github.com/yuin",
+      "name": "goldmark",
+      "version": "v1.1.27",
+      "purl": "pkg:golang/github.com/yuin/goldmark@v1.1.27"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
+      "group": "github.com/beevik",
+      "name": "etree",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/beevik/etree@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+      "group": "github.com/jonboulle",
+      "name": "clockwork",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "group": "github.com/fsnotify",
+      "name": "fsnotify",
+      "version": "v1.4.7",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+      "group": "github.com/hpcloud",
+      "name": "tail",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+      "group": "gopkg.in",
+      "name": "fsnotify.v1",
+      "version": "v1.4.7",
+      "purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "group": "gopkg.in",
+      "name": "tomb.v1",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "group": "github.com/json-iterator",
+      "name": "go",
+      "version": "v1.1.9",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "group": "github.com/google",
+      "name": "gofuzz",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "group": "github.com/modern-go",
+      "name": "concurrent",
+      "version": "v0.0.0-20180228061459-e0a39a4cb421",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "group": "github.com/modern-go",
+      "name": "reflect2",
+      "version": "v0.0.0-20180701023420-4b7aa43c6742",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+      "group": "github.com/gopherjs",
+      "name": "gopherjs",
+      "version": "v0.0.0-20181017120253-0766667cb4d1",
+      "purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+      "group": "github.com/jtolds",
+      "name": "gls",
+      "version": "v4.20.0+incompatible",
+      "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+      "group": "github.com/smartystreets",
+      "name": "assertions",
+      "version": "v0.0.0-20180927180507-b2de0cb4f26d",
+      "purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+      "group": "github.com/golang",
+      "name": "snappy",
+      "version": "v0.0.0-20180518054509-2e65f85255db",
+      "purl": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+      "group": "github.com/cskr",
+      "name": "pubsub",
+      "version": "v1.0.2",
+      "purl": "pkg:golang/github.com/cskr/pubsub@v1.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-peertaskqueue",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-testutil",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+      "group": "github.com/jackpal",
+      "name": "gateway",
+      "version": "v1.0.5",
+      "purl": "pkg:golang/github.com/jackpal/gateway@v1.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+      "group": "github.com/jackpal",
+      "name": "go-nat-pmp",
+      "version": "v1.0.1",
+      "purl": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+      "group": "github.com/koron",
+      "name": "go-ssdp",
+      "version": "v0.0.0-20180514024734-4a0ed625a78b",
+      "purl": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+      "group": "github.com/dgrijalva",
+      "name": "jwt-go",
+      "version": "v3.2.0+incompatible",
+      "purl": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-pq",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+      "dependsOn": [
+        "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+        "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+        "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+        "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+        "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+        "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+      "dependsOn": [
+        "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.3.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+      "dependsOn": [
+        "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+      "dependsOn": [
+        "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/kr/pretty@v0.2.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+      "dependsOn": [
+        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/github.com/onsi/gomega@v1.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+      "dependsOn": [
+        "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+        "pkg:golang/golang.org/x/mod@v0.2.0",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+        "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+        "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+        "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/github.com/onsi/gomega@v1.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+      "dependsOn": [
+        "pkg:golang/github.com/aead/siphash@v1.0.1",
+        "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+        "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+        "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+        "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+        "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+        "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+        "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+        "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+        "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/github.com/onsi/gomega@v1.5.0",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+      "dependsOn": [
+        "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+      "dependsOn": [
+        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+        "pkg:golang/github.com/kr/pretty@v0.2.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/text@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+        "pkg:golang/github.com/go-playground/locales@v0.13.0",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-playground/locales@v0.13.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/huin/goupnp@v1.0.0",
+        "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+        "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+        "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+        "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+      "dependsOn": [
+        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/github.com/google/go-cmp@v0.5.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+      "dependsOn": [
+        "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+        "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+        "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+        "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+        "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+        "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/pkg/errors@v0.8.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+      "dependsOn": [
+        "pkg:golang/github.com/google/go-cmp@v0.5.4",
+        "pkg:golang/github.com/kr/pretty@v0.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "dependsOn": [
+        "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+        "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+        "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+      "dependsOn": [
+        "pkg:golang/github.com/google/go-cmp@v0.5.4",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/text@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/pty@v1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
+      "dependsOn": [
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3",
+        "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.0.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+      "dependsOn": []
+    }
+  ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
@@ -1,1369 +1,2199 @@
 {
-  "bomFormat" : "CycloneDX",
-  "specVersion" : "1.4",
-  "version" : 1,
-  "metadata" : {
-    "component" : {
-      "type" : "application",
-      "bom-ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-      "group" : "github.com/rhecosystemappeng/saasi",
-      "name" : "deployer",
-      "version" : "v0.0.0",
-      "purl" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+      "group": "github.com/rhecosystemappeng/saasi",
+      "name": "deployer",
+      "version": "v0.0.0",
+      "purl": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
     }
   },
-  "components" : [ {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
-    "group" : "github.com/stretchr",
-    "name" : "testify",
-    "version" : "v1.8.3",
-    "purl" : "pkg:golang/github.com/stretchr/testify@v1.8.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "group" : "github.com/davecgh",
-    "name" : "go-spew",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "group" : "github.com/pmezard",
-    "name" : "go-difflib",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "group" : "github.com/stretchr",
-    "name" : "objx",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-    "group" : "gopkg.in",
-    "name" : "yaml.v2",
-    "version" : "v2.4.0",
-    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-    "group" : "gopkg.in",
-    "name" : "yaml.v3",
-    "version" : "v3.0.1",
-    "purl" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/go.opencensus.io@v0.22.4",
-    "name" : "go.opencensus.io",
-    "version" : "v0.22.4",
-    "purl" : "pkg:golang/go.opencensus.io@v0.22.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
-    "group" : "github.com/golang",
-    "name" : "protobuf",
-    "version" : "v1.5.2",
-    "purl" : "pkg:golang/github.com/golang/protobuf@v1.5.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
-    "group" : "github.com/google",
-    "name" : "go-cmp",
-    "version" : "v0.5.9",
-    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "group" : "github.com/hashicorp",
-    "name" : "golang-lru",
-    "version" : "v0.5.1",
-    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/net@v0.10.0",
-    "group" : "golang.org/x",
-    "name" : "net",
-    "version" : "v0.10.0",
-    "purl" : "pkg:golang/golang.org/x/net@v0.10.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-    "group" : "google.golang.org",
-    "name" : "genproto",
-    "version" : "v0.0.0-20201019141844-1ed22bb0c154",
-    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
-    "group" : "google.golang.org",
-    "name" : "grpc",
-    "version" : "v1.31.0",
-    "purl" : "pkg:golang/google.golang.org/grpc@v1.31.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-    "group" : "github.com/golang",
-    "name" : "groupcache",
-    "version" : "v0.0.0-20210331224755-41bb18bfe9da",
-    "purl" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
-    "group" : "golang.org/x",
-    "name" : "sys",
-    "version" : "v0.8.0",
-    "purl" : "pkg:golang/golang.org/x/sys@v0.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/text@v0.9.0",
-    "group" : "golang.org/x",
-    "name" : "text",
-    "version" : "v0.9.0",
-    "purl" : "pkg:golang/golang.org/x/text@v0.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-    "group" : "github.com/go-openapi",
-    "name" : "jsonreference",
-    "version" : "v0.20.0",
-    "purl" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-    "group" : "github.com/go-openapi",
-    "name" : "jsonpointer",
-    "version" : "v0.19.5",
-    "purl" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
-    "group" : "k8s.io/klog",
-    "name" : "v2",
-    "version" : "v2.80.1",
-    "purl" : "pkg:golang/k8s.io/klog/v2@v2.80.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-    "group" : "golang.org/x",
-    "name" : "image",
-    "version" : "v0.0.0-20190802002840-cff245a6509b",
-    "purl" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-    "group" : "github.com/mailru",
-    "name" : "easyjson",
-    "version" : "v0.7.6",
-    "purl" : "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
-    "group" : "github.com/josharian",
-    "name" : "intern",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/josharian/intern@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-    "group" : "github.com/cncf/udpa",
-    "name" : "go",
-    "version" : "v0.0.0-20191209042840-269d4d468f6f",
-    "purl" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-    "group" : "github.com/envoyproxy",
-    "name" : "protoc-gen-validate",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-    "group" : "cloud.google.com/go",
-    "name" : "bigquery",
-    "version" : "v1.8.0",
-    "purl" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
-    "group" : "cloud.google.com",
-    "name" : "go",
-    "version" : "v0.65.0",
-    "purl" : "pkg:golang/cloud.google.com/go@v0.65.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-    "group" : "cloud.google.com/go",
-    "name" : "storage",
-    "version" : "v1.10.0",
-    "purl" : "pkg:golang/cloud.google.com/go/storage@v1.10.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-    "group" : "github.com/googleapis/gax-go",
-    "name" : "v2",
-    "version" : "v2.0.5",
-    "purl" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
-    "group" : "golang.org/x",
-    "name" : "tools",
-    "version" : "v0.6.0",
-    "purl" : "pkg:golang/golang.org/x/tools@v0.6.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/api@v0.30.0",
-    "group" : "google.golang.org",
-    "name" : "api",
-    "version" : "v0.30.0",
-    "purl" : "pkg:golang/google.golang.org/api@v0.30.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-    "group" : "golang.org/x",
-    "name" : "exp",
-    "version" : "v0.0.0-20200224162631-6cc2880d07d6",
-    "purl" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
-    "group" : "golang.org/x",
-    "name" : "mod",
-    "version" : "v0.8.0",
-    "purl" : "pkg:golang/golang.org/x/mod@v0.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-    "group" : "honnef.co/go",
-    "name" : "tools",
-    "version" : "v0.0.1-2020.1.4",
-    "purl" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-    "group" : "cloud.google.com/go",
-    "name" : "pubsub",
-    "version" : "v1.3.1",
-    "purl" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
-    "group" : "google.golang.org",
-    "name" : "appengine",
-    "version" : "v1.6.7",
-    "purl" : "pkg:golang/google.golang.org/appengine@v1.6.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-    "group" : "golang.org/x",
-    "name" : "lint",
-    "version" : "v0.0.0-20200302205851-738671d3881b",
-    "purl" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-    "group" : "gopkg.in",
-    "name" : "check.v1",
-    "version" : "v1.0.0-20200227125254-8fa46927fb4f",
-    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-    "group" : "github.com/emicklei/go-restful",
-    "name" : "v3",
-    "version" : "v3.9.0",
-    "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-    "group" : "github.com/gin-gonic",
-    "name" : "gin",
-    "version" : "v1.9.1",
-    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-    "group" : "github.com/go-openapi",
-    "name" : "swag",
-    "version" : "v0.19.14",
-    "purl" : "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-    "group" : "github.com/gogo",
-    "name" : "protobuf",
-    "version" : "v1.3.2",
-    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
-    "group" : "github.com/google",
-    "name" : "gofuzz",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/google/gofuzz@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
-    "group" : "github.com/google",
-    "name" : "uuid",
-    "version" : "v1.1.2",
-    "purl" : "pkg:golang/github.com/google/uuid@v1.1.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
-    "group" : "github.com/imdario",
-    "name" : "mergo",
-    "version" : "v0.3.6",
-    "purl" : "pkg:golang/github.com/imdario/mergo@v0.3.6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
-    "group" : "github.com/json-iterator",
-    "name" : "go",
-    "version" : "v1.1.12",
-    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.12"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
-    "group" : "github.com/kr",
-    "name" : "pretty",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/kr/pretty@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/text@v0.2.0",
-    "group" : "github.com/kr",
-    "name" : "text",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/kr/text@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-    "group" : "github.com/modern-go",
-    "name" : "concurrent",
-    "version" : "v0.0.0-20180306012644-bacd9c7ef1dd",
-    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-    "group" : "github.com/modern-go",
-    "name" : "reflect2",
-    "version" : "v1.0.2",
-    "purl" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-    "group" : "github.com/munnerz",
-    "name" : "goautoneg",
-    "version" : "v0.0.0-20191010083416-a7dc8b61c822",
-    "purl" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-    "group" : "github.com/rogpeppe",
-    "name" : "go-internal",
-    "version" : "v1.9.0",
-    "purl" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
-    "group" : "github.com/spf13",
-    "name" : "pflag",
-    "version" : "v1.0.5",
-    "purl" : "pkg:golang/github.com/spf13/pflag@v1.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-    "group" : "golang.org/x",
-    "name" : "oauth2",
-    "version" : "v0.0.0-20220223155221-ee480838109b",
-    "purl" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/term@v0.8.0",
-    "group" : "golang.org/x",
-    "name" : "term",
-    "version" : "v0.8.0",
-    "purl" : "pkg:golang/golang.org/x/term@v0.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-    "group" : "golang.org/x",
-    "name" : "time",
-    "version" : "v0.0.0-20220210224613-90d013bbcef8",
-    "purl" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
-    "group" : "google.golang.org",
-    "name" : "protobuf",
-    "version" : "v1.30.0",
-    "purl" : "pkg:golang/google.golang.org/protobuf@v1.30.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-    "group" : "gopkg.in",
-    "name" : "inf.v0",
-    "version" : "v0.9.1",
-    "purl" : "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/api@v0.26.1",
-    "group" : "k8s.io",
-    "name" : "api",
-    "version" : "v0.26.1",
-    "purl" : "pkg:golang/k8s.io/api@v0.26.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
-    "group" : "k8s.io",
-    "name" : "apimachinery",
-    "version" : "v0.26.1",
-    "purl" : "pkg:golang/k8s.io/apimachinery@v0.26.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
-    "group" : "k8s.io",
-    "name" : "client-go",
-    "version" : "v0.26.1",
-    "purl" : "pkg:golang/k8s.io/client-go@v0.26.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-    "group" : "k8s.io",
-    "name" : "kube-openapi",
-    "version" : "v0.0.0-20221012153701-172d655c2280",
-    "purl" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-    "group" : "k8s.io",
-    "name" : "utils",
-    "version" : "v0.0.0-20221107191617-1a15be271d1d",
-    "purl" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-    "group" : "sigs.k8s.io",
-    "name" : "json",
-    "version" : "v0.0.0-20220713155537-f223a00ba0e2",
-    "purl" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-    "group" : "sigs.k8s.io/structured-merge-diff",
-    "name" : "v4",
-    "version" : "v4.2.3",
-    "purl" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-    "group" : "sigs.k8s.io",
-    "name" : "yaml",
-    "version" : "v1.3.0",
-    "purl" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "group" : "golang.org/x",
-    "name" : "xerrors",
-    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
-    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
-    "group" : "golang.org/x",
-    "name" : "crypto",
-    "version" : "v0.9.0",
-    "purl" : "pkg:golang/golang.org/x/crypto@v0.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-    "group" : "github.com/kisielk",
-    "name" : "errcheck",
-    "version" : "v1.5.0",
-    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "group" : "github.com/kisielk",
-    "name" : "gotool",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
-    "group" : "github.com/golang",
-    "name" : "mock",
-    "version" : "v1.4.4",
-    "purl" : "pkg:golang/github.com/golang/mock@v1.4.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
-    "group" : "rsc.io/quote",
-    "name" : "v3",
-    "version" : "v3.1.0",
-    "purl" : "pkg:golang/rsc.io/quote/v3@v3.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-    "group" : "golang.org/x",
-    "name" : "sync",
-    "version" : "v0.0.0-20201020160332-67f06af15bc9",
-    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-    "group" : "github.com/niemeyer",
-    "name" : "pretty",
-    "version" : "v0.0.0-20200227124842-a10e7caefd8e",
-    "purl" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-    "group" : "golang.org/x",
-    "name" : "mobile",
-    "version" : "v0.0.0-20190719004257-d2bd2a29d028",
-    "purl" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-    "group" : "github.com/armon",
-    "name" : "go-socks5",
-    "version" : "v0.0.0-20160902184237-e75332964ef5",
-    "purl" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-    "group" : "github.com/elazarl",
-    "name" : "goproxy",
-    "version" : "v0.0.0-20180725130230-947c36da3153",
-    "purl" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-    "group" : "github.com/evanphx",
-    "name" : "json-patch",
-    "version" : "v4.12.0+incompatible",
-    "purl" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
-    "group" : "github.com/moby",
-    "name" : "spdystream",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/moby/spdystream@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-    "group" : "github.com/mxk",
-    "name" : "go-flowrate",
-    "version" : "v0.0.0-20140419014527-cca7078d478f",
-    "purl" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-    "group" : "github.com/onsi/ginkgo",
-    "name" : "v2",
-    "version" : "v2.4.0",
-    "purl" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
-    "group" : "github.com/onsi",
-    "name" : "gomega",
-    "version" : "v1.23.0",
-    "purl" : "pkg:golang/github.com/onsi/gomega@v1.23.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
-    "group" : "github.com/pkg",
-    "name" : "errors",
-    "version" : "v0.9.1",
-    "purl" : "pkg:golang/github.com/pkg/errors@v0.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
-    "group" : "github.com/google/martian",
-    "name" : "v3",
-    "version" : "v3.0.0",
-    "purl" : "pkg:golang/github.com/google/martian/v3@v3.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-    "group" : "github.com/envoyproxy",
-    "name" : "go-control-plane",
-    "version" : "v0.9.4",
-    "purl" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-    "group" : "github.com/census-instrumentation",
-    "name" : "opencensus-proto",
-    "version" : "v0.2.1",
-    "purl" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-    "group" : "github.com/prometheus",
-    "name" : "client_model",
-    "version" : "v0.0.0-20190812154241-14fe0d1b01d4",
-    "purl" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-    "group" : "github.com/bytedance",
-    "name" : "sonic",
-    "version" : "v1.9.1",
-    "purl" : "pkg:golang/github.com/bytedance/sonic@v1.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "group" : "github.com/gin-contrib",
-    "name" : "sse",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-    "group" : "github.com/go-playground/validator",
-    "name" : "v10",
-    "version" : "v10.14.0",
-    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
-    "group" : "github.com/goccy",
-    "name" : "go-json",
-    "version" : "v0.10.2",
-    "purl" : "pkg:golang/github.com/goccy/go-json@v0.10.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-    "group" : "github.com/mattn",
-    "name" : "go-isatty",
-    "version" : "v0.0.19",
-    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-    "group" : "github.com/pelletier/go-toml",
-    "name" : "v2",
-    "version" : "v2.0.8",
-    "purl" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-    "group" : "github.com/ugorji/go",
-    "name" : "codec",
-    "version" : "v1.2.11",
-    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-    "group" : "github.com/chenzhuoyu",
-    "name" : "base64x",
-    "version" : "v0.0.0-20221115062448-fe3a3abad311",
-    "purl" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-    "group" : "github.com/gabriel-vasile",
-    "name" : "mimetype",
-    "version" : "v1.4.2",
-    "purl" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
-    "group" : "github.com/go-playground",
-    "name" : "locales",
-    "version" : "v0.14.1",
-    "purl" : "pkg:golang/github.com/go-playground/locales@v0.14.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-    "group" : "github.com/go-playground",
-    "name" : "universal-translator",
-    "version" : "v0.18.1",
-    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-    "group" : "github.com/klauspost/cpuid",
-    "name" : "v2",
-    "version" : "v2.2.4",
-    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-    "group" : "github.com/leodido",
-    "name" : "go-urn",
-    "version" : "v1.2.4",
-    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-    "group" : "github.com/twitchyliquid64",
-    "name" : "golang-asm",
-    "version" : "v0.15.1",
-    "purl" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
-    "group" : "golang.org/x",
-    "name" : "arch",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/golang.org/x/arch@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-    "group" : "github.com/gregjones",
-    "name" : "httpcache",
-    "version" : "v0.0.0-20180305231024-9cad4c3443a7",
-    "purl" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-    "group" : "github.com/peterbourgon",
-    "name" : "diskv",
-    "version" : "v2.0.1+incompatible",
-    "purl" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/btree@v1.0.1",
-    "group" : "github.com/google",
-    "name" : "btree",
-    "version" : "v1.0.1",
-    "purl" : "pkg:golang/github.com/google/btree@v1.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-    "group" : "gopkg.in",
-    "name" : "errgo.v2",
-    "version" : "v2.1.0",
-    "purl" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-    "group" : "github.com/pkg",
-    "name" : "diff",
-    "version" : "v0.0.0-20210226163009-20ebb0f2a09e",
-    "purl" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-    "group" : "github.com/burntsushi",
-    "name" : "toml",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/burntsushi/toml@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
-    "group" : "github.com/google",
-    "name" : "renameio",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/google/renameio@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-    "group" : "github.com/google",
-    "name" : "pprof",
-    "version" : "v0.0.0-20200708004538-1a94d8640e99",
-    "purl" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
-    "group" : "github.com/chzyer",
-    "name" : "logex",
-    "version" : "v1.1.10",
-    "purl" : "pkg:golang/github.com/chzyer/logex@v1.1.10"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-    "group" : "github.com/chzyer",
-    "name" : "readline",
-    "version" : "v0.0.0-20180603132655-2972be24d48e",
-    "purl" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-    "group" : "github.com/chzyer",
-    "name" : "test",
-    "version" : "v0.0.0-20180213035817-a1ea475d72b1",
-    "purl" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-    "group" : "github.com/ianlancetaylor",
-    "name" : "demangle",
-    "version" : "v0.0.0-20181102032728-5e5cf60278f6",
-    "purl" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-    "group" : "github.com/nytimes",
-    "name" : "gziphandler",
-    "version" : "v0.0.0-20170623195520-56545f4a5d46",
-    "purl" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-    "group" : "github.com/asaskevich",
-    "name" : "govalidator",
-    "version" : "v0.0.0-20190424111038-f61b66f89f4a",
-    "purl" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-    "group" : "github.com/mitchellh",
-    "name" : "mapstructure",
-    "version" : "v1.1.2",
-    "purl" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-    "group" : "k8s.io",
-    "name" : "gengo",
-    "version" : "v0.0.0-20210813121822-485abfe95c7c",
-    "purl" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-    "group" : "github.com/puerkitobio",
-    "name" : "purell",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-    "group" : "github.com/puerkitobio",
-    "name" : "urlesc",
-    "version" : "v0.0.0-20170810143723-de5bf2ad4578",
-    "purl" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-    "group" : "github.com/jstemmer",
-    "name" : "go-junit-report",
-    "version" : "v0.9.1",
-    "purl" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-    "group" : "cloud.google.com/go",
-    "name" : "datastore",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "group" : "github.com/kr",
-    "name" : "pty",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
-    "group" : "github.com/creack",
-    "name" : "pty",
-    "version" : "v1.1.9",
-    "purl" : "pkg:golang/github.com/creack/pty@v1.1.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-    "group" : "github.com/yuin",
-    "name" : "goldmark",
-    "version" : "v1.2.1",
-    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-    "group" : "github.com/golang",
-    "name" : "glog",
-    "version" : "v0.0.0-20160126235308-23def4e6c14b",
-    "purl" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
-    "group" : "github.com/client9",
-    "name" : "misspell",
-    "version" : "v0.3.4",
-    "purl" : "pkg:golang/github.com/client9/misspell@v0.3.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
-    "group" : "rsc.io",
-    "name" : "sampler",
-    "version" : "v1.3.0",
-    "purl" : "pkg:golang/rsc.io/sampler@v1.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-    "group" : "dmitri.shuralyov.com/gpu",
-    "name" : "mtl",
-    "version" : "v0.0.0-20190408044501-666a987793e9",
-    "purl" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-    "group" : "github.com/burntsushi",
-    "name" : "xgb",
-    "version" : "v0.0.0-20160522181843-27f122750802",
-    "purl" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-    "group" : "github.com/go-gl/glfw/v3.3",
-    "name" : "glfw",
-    "version" : "v0.0.0-20200222043503-6f7a984d4dc4",
-    "purl" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
-    "group" : "github.com/go-gl",
-    "name" : "glfw",
-    "version" : "v0.0.0-20190409004039-e6da0acd62b1",
-    "purl" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-    "group" : "github.com/google",
-    "name" : "martian",
-    "version" : "v2.1.0+incompatible",
-    "purl" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-    "group" : "rsc.io",
-    "name" : "binaryregexp",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-    "group" : "github.com/stoewer",
-    "name" : "go-strcase",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-    "group" : "github.com/docopt",
-    "name" : "docopt-go",
-    "version" : "v0.0.0-20180111231733-ee0de3bc6815",
-    "purl" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
-  } ],
-  "dependencies" : [ {
-    "ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/gin-gonic/gin@v1.9.1", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/client-go@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
-  }, {
-    "ref" : "pkg:golang/go.opencensus.io@v0.22.4",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
-    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/protobuf@v1.30.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
-    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/net@v0.10.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/term@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
-    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/client9/misspell@v0.3.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/text@v0.9.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-    "dependsOn" : [ "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-    "dependsOn" : [ "pkg:golang/github.com/josharian/intern@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/google.golang.org/grpc@v1.31.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b" ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible", "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/github.com/google/martian/v3@v3.0.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/rsc.io/binaryregexp@v0.2.0" ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-    "dependsOn" : [ "pkg:golang/google.golang.org/grpc@v1.31.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
-    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.2.1", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/api@v0.30.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/golang/protobuf@v1.5.2" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-    "dependsOn" : [ "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9", "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802", "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-    "dependsOn" : [ "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/google/renameio@v0.1.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-    "dependsOn" : [ "pkg:golang/github.com/bytedance/sonic@v1.9.1", "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.14.0", "pkg:golang/github.com/goccy/go-json@v0.10.2", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mattn/go-isatty@v0.0.19", "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/github.com/ugorji/go/codec@v1.2.11", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2", "pkg:golang/github.com/go-playground/locales@v0.14.1", "pkg:golang/github.com/go-playground/universal-translator@v0.18.1", "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4", "pkg:golang/github.com/leodido/go-urn@v1.2.4", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1", "pkg:golang/golang.org/x/arch@v0.3.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.5.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
-    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/text@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1", "pkg:golang/github.com/creack/pty@v1.1.9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-    "dependsOn" : [ "pkg:golang/gopkg.in/errgo.v2@v2.1.0", "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e" ]
-  }, {
-    "ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/term@v0.8.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/api@v0.26.1",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
-    "dependsOn" : [ "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-    "dependsOn" : [ "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46", "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/puerkitobio/purell@v1.1.1", "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/k8s.io/klog/v2@v2.80.1" ]
-  }, {
-    "ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-    "dependsOn" : [ "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd" ]
-  }, {
-    "ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/rsc.io/quote/v3@v3.1.0" ]
-  }, {
-    "ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
-    "dependsOn" : [ "pkg:golang/rsc.io/sampler@v1.3.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-    "dependsOn" : [ "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-    "dependsOn" : [ "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/github.com/google/go-cmp@v0.5.9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
-  }, {
-    "ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/btree@v1.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
-  }, {
-    "ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-    "dependsOn" : [ "pkg:golang/github.com/chzyer/logex@v1.1.10", "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e", "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1", "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6", "pkg:golang/golang.org/x/sys@v0.8.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/tools@v0.6.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
-  }, {
-    "ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-    "dependsOn" : [ ]
-  } ]
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+      "group": "github.com/stretchr",
+      "name": "testify",
+      "version": "v1.8.3",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "group": "github.com/davecgh",
+      "name": "go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "group": "github.com/pmezard",
+      "name": "go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "group": "github.com/stretchr",
+      "name": "objx",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "version": "v2.4.0",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "group": "gopkg.in",
+      "name": "yaml.v3",
+      "version": "v3.0.1",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/go.opencensus.io@v0.22.4",
+      "name": "go.opencensus.io",
+      "version": "v0.22.4",
+      "purl": "pkg:golang/go.opencensus.io@v0.22.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+      "group": "github.com/golang",
+      "name": "protobuf",
+      "version": "v1.5.2",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "group": "github.com/google",
+      "name": "go-cmp",
+      "version": "v0.5.9",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "group": "github.com/hashicorp",
+      "name": "golang-lru",
+      "version": "v0.5.1",
+      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0",
+      "group": "golang.org/x",
+      "name": "net",
+      "version": "v0.10.0",
+      "purl": "pkg:golang/golang.org/x/net@v0.10.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+      "group": "google.golang.org",
+      "name": "genproto",
+      "version": "v0.0.0-20201019141844-1ed22bb0c154",
+      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
+      "group": "google.golang.org",
+      "name": "grpc",
+      "version": "v1.31.0",
+      "purl": "pkg:golang/google.golang.org/grpc@v1.31.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "group": "github.com/golang",
+      "name": "groupcache",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+      "group": "golang.org/x",
+      "name": "sys",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/sys@v0.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0",
+      "group": "golang.org/x",
+      "name": "text",
+      "version": "v0.9.0",
+      "purl": "pkg:golang/golang.org/x/text@v0.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+      "group": "github.com/go-openapi",
+      "name": "jsonreference",
+      "version": "v0.20.0",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+      "group": "github.com/go-openapi",
+      "name": "jsonpointer",
+      "version": "v0.19.5",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+      "group": "k8s.io/klog",
+      "name": "v2",
+      "version": "v2.80.1",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+      "group": "golang.org/x",
+      "name": "image",
+      "version": "v0.0.0-20190802002840-cff245a6509b",
+      "purl": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+      "group": "github.com/mailru",
+      "name": "easyjson",
+      "version": "v0.7.6",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "group": "github.com/josharian",
+      "name": "intern",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+      "group": "github.com/cncf/udpa",
+      "name": "go",
+      "version": "v0.0.0-20191209042840-269d4d468f6f",
+      "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+      "group": "github.com/envoyproxy",
+      "name": "protoc-gen-validate",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+      "group": "cloud.google.com/go",
+      "name": "bigquery",
+      "version": "v1.8.0",
+      "purl": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+      "group": "cloud.google.com",
+      "name": "go",
+      "version": "v0.65.0",
+      "purl": "pkg:golang/cloud.google.com/go@v0.65.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+      "group": "cloud.google.com/go",
+      "name": "storage",
+      "version": "v1.10.0",
+      "purl": "pkg:golang/cloud.google.com/go/storage@v1.10.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+      "group": "github.com/googleapis/gax-go",
+      "name": "v2",
+      "version": "v2.0.5",
+      "purl": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+      "group": "golang.org/x",
+      "name": "tools",
+      "version": "v0.6.0",
+      "purl": "pkg:golang/golang.org/x/tools@v0.6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/api@v0.30.0",
+      "group": "google.golang.org",
+      "name": "api",
+      "version": "v0.30.0",
+      "purl": "pkg:golang/google.golang.org/api@v0.30.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+      "group": "golang.org/x",
+      "name": "exp",
+      "version": "v0.0.0-20200224162631-6cc2880d07d6",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+      "group": "golang.org/x",
+      "name": "mod",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/mod@v0.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+      "group": "honnef.co/go",
+      "name": "tools",
+      "version": "v0.0.1-2020.1.4",
+      "purl": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+      "group": "cloud.google.com/go",
+      "name": "pubsub",
+      "version": "v1.3.1",
+      "purl": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+      "group": "google.golang.org",
+      "name": "appengine",
+      "version": "v1.6.7",
+      "purl": "pkg:golang/google.golang.org/appengine@v1.6.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+      "group": "golang.org/x",
+      "name": "lint",
+      "version": "v0.0.0-20200302205851-738671d3881b",
+      "purl": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+      "group": "gopkg.in",
+      "name": "check.v1",
+      "version": "v1.0.0-20200227125254-8fa46927fb4f",
+      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+      "group": "github.com/emicklei/go-restful",
+      "name": "v3",
+      "version": "v3.9.0",
+      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+      "group": "github.com/gin-gonic",
+      "name": "gin",
+      "version": "v1.9.1",
+      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+      "group": "github.com/go-openapi",
+      "name": "swag",
+      "version": "v0.19.14",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "group": "github.com/gogo",
+      "name": "protobuf",
+      "version": "v1.3.2",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+      "group": "github.com/google",
+      "name": "gofuzz",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2",
+      "group": "github.com/google",
+      "name": "uuid",
+      "version": "v1.1.2",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+      "group": "github.com/imdario",
+      "name": "mergo",
+      "version": "v0.3.6",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "group": "github.com/json-iterator",
+      "name": "go",
+      "version": "v1.1.12",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
+      "group": "github.com/kr",
+      "name": "pretty",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/kr/pretty@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0",
+      "group": "github.com/kr",
+      "name": "text",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/kr/text@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "group": "github.com/modern-go",
+      "name": "concurrent",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "group": "github.com/modern-go",
+      "name": "reflect2",
+      "version": "v1.0.2",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "group": "github.com/munnerz",
+      "name": "goautoneg",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+      "group": "github.com/rogpeppe",
+      "name": "go-internal",
+      "version": "v1.9.0",
+      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "group": "github.com/spf13",
+      "name": "pflag",
+      "version": "v1.0.5",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+      "group": "golang.org/x",
+      "name": "oauth2",
+      "version": "v0.0.0-20220223155221-ee480838109b",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0",
+      "group": "golang.org/x",
+      "name": "term",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/term@v0.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+      "group": "golang.org/x",
+      "name": "time",
+      "version": "v0.0.0-20220210224613-90d013bbcef8",
+      "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+      "group": "google.golang.org",
+      "name": "protobuf",
+      "version": "v1.30.0",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "group": "gopkg.in",
+      "name": "inf.v0",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/api@v0.26.1",
+      "group": "k8s.io",
+      "name": "api",
+      "version": "v0.26.1",
+      "purl": "pkg:golang/k8s.io/api@v0.26.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
+      "group": "k8s.io",
+      "name": "apimachinery",
+      "version": "v0.26.1",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.26.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1",
+      "group": "k8s.io",
+      "name": "client-go",
+      "version": "v0.26.1",
+      "purl": "pkg:golang/k8s.io/client-go@v0.26.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+      "group": "k8s.io",
+      "name": "kube-openapi",
+      "version": "v0.0.0-20221012153701-172d655c2280",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+      "group": "k8s.io",
+      "name": "utils",
+      "version": "v0.0.0-20221107191617-1a15be271d1d",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+      "group": "sigs.k8s.io",
+      "name": "json",
+      "version": "v0.0.0-20220713155537-f223a00ba0e2",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "group": "sigs.k8s.io/structured-merge-diff",
+      "name": "v4",
+      "version": "v4.2.3",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "group": "sigs.k8s.io",
+      "name": "yaml",
+      "version": "v1.3.0",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "group": "golang.org/x",
+      "name": "xerrors",
+      "version": "v0.0.0-20200804184101-5ec99f83aff1",
+      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+      "group": "golang.org/x",
+      "name": "crypto",
+      "version": "v0.9.0",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+      "group": "github.com/kisielk",
+      "name": "errcheck",
+      "version": "v1.5.0",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "group": "github.com/kisielk",
+      "name": "gotool",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/mock@v1.4.4",
+      "group": "github.com/golang",
+      "name": "mock",
+      "version": "v1.4.4",
+      "purl": "pkg:golang/github.com/golang/mock@v1.4.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
+      "group": "rsc.io/quote",
+      "name": "v3",
+      "version": "v3.1.0",
+      "purl": "pkg:golang/rsc.io/quote/v3@v3.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+      "group": "golang.org/x",
+      "name": "sync",
+      "version": "v0.0.0-20201020160332-67f06af15bc9",
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+      "group": "github.com/niemeyer",
+      "name": "pretty",
+      "version": "v0.0.0-20200227124842-a10e7caefd8e",
+      "purl": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+      "group": "golang.org/x",
+      "name": "mobile",
+      "version": "v0.0.0-20190719004257-d2bd2a29d028",
+      "purl": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+      "group": "github.com/armon",
+      "name": "go-socks5",
+      "version": "v0.0.0-20160902184237-e75332964ef5",
+      "purl": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+      "group": "github.com/elazarl",
+      "name": "goproxy",
+      "version": "v0.0.0-20180725130230-947c36da3153",
+      "purl": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+      "group": "github.com/evanphx",
+      "name": "json-patch",
+      "version": "v4.12.0+incompatible",
+      "purl": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "group": "github.com/moby",
+      "name": "spdystream",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "group": "github.com/mxk",
+      "name": "go-flowrate",
+      "version": "v0.0.0-20140419014527-cca7078d478f",
+      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+      "group": "github.com/onsi/ginkgo",
+      "name": "v2",
+      "version": "v2.4.0",
+      "purl": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
+      "group": "github.com/onsi",
+      "name": "gomega",
+      "version": "v1.23.0",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.23.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "group": "github.com/pkg",
+      "name": "errors",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
+      "group": "github.com/google/martian",
+      "name": "v3",
+      "version": "v3.0.0",
+      "purl": "pkg:golang/github.com/google/martian/v3@v3.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+      "group": "github.com/envoyproxy",
+      "name": "go-control-plane",
+      "version": "v0.9.4",
+      "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+      "group": "github.com/census-instrumentation",
+      "name": "opencensus-proto",
+      "version": "v0.2.1",
+      "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+      "group": "github.com/prometheus",
+      "name": "client_model",
+      "version": "v0.0.0-20190812154241-14fe0d1b01d4",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+      "group": "github.com/bytedance",
+      "name": "sonic",
+      "version": "v1.9.1",
+      "purl": "pkg:golang/github.com/bytedance/sonic@v1.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "group": "github.com/gin-contrib",
+      "name": "sse",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+      "group": "github.com/go-playground/validator",
+      "name": "v10",
+      "version": "v10.14.0",
+      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+      "group": "github.com/goccy",
+      "name": "go-json",
+      "version": "v0.10.2",
+      "purl": "pkg:golang/github.com/goccy/go-json@v0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+      "group": "github.com/mattn",
+      "name": "go-isatty",
+      "version": "v0.0.19",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+      "group": "github.com/pelletier/go-toml",
+      "name": "v2",
+      "version": "v2.0.8",
+      "purl": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+      "group": "github.com/ugorji/go",
+      "name": "codec",
+      "version": "v1.2.11",
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+      "group": "github.com/chenzhuoyu",
+      "name": "base64x",
+      "version": "v0.0.0-20221115062448-fe3a3abad311",
+      "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+      "group": "github.com/gabriel-vasile",
+      "name": "mimetype",
+      "version": "v1.4.2",
+      "purl": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+      "group": "github.com/go-playground",
+      "name": "locales",
+      "version": "v0.14.1",
+      "purl": "pkg:golang/github.com/go-playground/locales@v0.14.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+      "group": "github.com/go-playground",
+      "name": "universal-translator",
+      "version": "v0.18.1",
+      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+      "group": "github.com/klauspost/cpuid",
+      "name": "v2",
+      "version": "v2.2.4",
+      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+      "group": "github.com/leodido",
+      "name": "go-urn",
+      "version": "v1.2.4",
+      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+      "group": "github.com/twitchyliquid64",
+      "name": "golang-asm",
+      "version": "v0.15.1",
+      "purl": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+      "group": "golang.org/x",
+      "name": "arch",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/golang.org/x/arch@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+      "group": "github.com/gregjones",
+      "name": "httpcache",
+      "version": "v0.0.0-20180305231024-9cad4c3443a7",
+      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+      "group": "github.com/peterbourgon",
+      "name": "diskv",
+      "version": "v2.0.1+incompatible",
+      "purl": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1",
+      "group": "github.com/google",
+      "name": "btree",
+      "version": "v1.0.1",
+      "purl": "pkg:golang/github.com/google/btree@v1.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+      "group": "gopkg.in",
+      "name": "errgo.v2",
+      "version": "v2.1.0",
+      "purl": "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "group": "github.com/pkg",
+      "name": "diff",
+      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
+      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+      "group": "github.com/burntsushi",
+      "name": "toml",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/burntsushi/toml@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/renameio@v0.1.0",
+      "group": "github.com/google",
+      "name": "renameio",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/google/renameio@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+      "group": "github.com/google",
+      "name": "pprof",
+      "version": "v0.0.0-20200708004538-1a94d8640e99",
+      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
+      "group": "github.com/chzyer",
+      "name": "logex",
+      "version": "v1.1.10",
+      "purl": "pkg:golang/github.com/chzyer/logex@v1.1.10"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+      "group": "github.com/chzyer",
+      "name": "readline",
+      "version": "v0.0.0-20180603132655-2972be24d48e",
+      "purl": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+      "group": "github.com/chzyer",
+      "name": "test",
+      "version": "v0.0.0-20180213035817-a1ea475d72b1",
+      "purl": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+      "group": "github.com/ianlancetaylor",
+      "name": "demangle",
+      "version": "v0.0.0-20181102032728-5e5cf60278f6",
+      "purl": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+      "group": "github.com/nytimes",
+      "name": "gziphandler",
+      "version": "v0.0.0-20170623195520-56545f4a5d46",
+      "purl": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+      "group": "github.com/asaskevich",
+      "name": "govalidator",
+      "version": "v0.0.0-20190424111038-f61b66f89f4a",
+      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "group": "github.com/mitchellh",
+      "name": "mapstructure",
+      "version": "v1.1.2",
+      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+      "group": "k8s.io",
+      "name": "gengo",
+      "version": "v0.0.0-20210813121822-485abfe95c7c",
+      "purl": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+      "group": "github.com/puerkitobio",
+      "name": "purell",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+      "group": "github.com/puerkitobio",
+      "name": "urlesc",
+      "version": "v0.0.0-20170810143723-de5bf2ad4578",
+      "purl": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+      "group": "github.com/jstemmer",
+      "name": "go-junit-report",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+      "group": "cloud.google.com/go",
+      "name": "datastore",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "group": "github.com/kr",
+      "name": "pty",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/kr/pty@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+      "group": "github.com/creack",
+      "name": "pty",
+      "version": "v1.1.9",
+      "purl": "pkg:golang/github.com/creack/pty@v1.1.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+      "group": "github.com/yuin",
+      "name": "goldmark",
+      "version": "v1.2.1",
+      "purl": "pkg:golang/github.com/yuin/goldmark@v1.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+      "group": "github.com/golang",
+      "name": "glog",
+      "version": "v0.0.0-20160126235308-23def4e6c14b",
+      "purl": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/client9/misspell@v0.3.4",
+      "group": "github.com/client9",
+      "name": "misspell",
+      "version": "v0.3.4",
+      "purl": "pkg:golang/github.com/client9/misspell@v0.3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/rsc.io/sampler@v1.3.0",
+      "group": "rsc.io",
+      "name": "sampler",
+      "version": "v1.3.0",
+      "purl": "pkg:golang/rsc.io/sampler@v1.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+      "group": "dmitri.shuralyov.com/gpu",
+      "name": "mtl",
+      "version": "v0.0.0-20190408044501-666a987793e9",
+      "purl": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+      "group": "github.com/burntsushi",
+      "name": "xgb",
+      "version": "v0.0.0-20160522181843-27f122750802",
+      "purl": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+      "group": "github.com/go-gl/glfw/v3.3",
+      "name": "glfw",
+      "version": "v0.0.0-20200222043503-6f7a984d4dc4",
+      "purl": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+      "group": "github.com/go-gl",
+      "name": "glfw",
+      "version": "v0.0.0-20190409004039-e6da0acd62b1",
+      "purl": "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+      "group": "github.com/google",
+      "name": "martian",
+      "version": "v2.1.0+incompatible",
+      "purl": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+      "group": "rsc.io",
+      "name": "binaryregexp",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+      "group": "github.com/stoewer",
+      "name": "go-strcase",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+      "group": "github.com/docopt",
+      "name": "docopt-go",
+      "version": "v0.0.0-20180111231733-ee0de3bc6815",
+      "purl": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+        "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/imdario/mergo@v0.3.6",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/term@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/k8s.io/api@v0.26.1",
+        "pkg:golang/k8s.io/apimachinery@v0.26.1",
+        "pkg:golang/k8s.io/client-go@v0.26.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/go.opencensus.io@v0.22.4",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+      "dependsOn": [
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/term@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
+      "dependsOn": [
+        "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+        "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@v1.4.4",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+        "pkg:golang/github.com/client9/misspell@v0.3.4",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+      "dependsOn": [
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+      "dependsOn": [
+        "pkg:golang/github.com/josharian/intern@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+      "dependsOn": [
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/google.golang.org/grpc@v1.31.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/golang/mock@v1.4.4",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+        "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/github.com/google/btree@v1.0.1",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/github.com/google/martian/v3@v3.0.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+      "dependsOn": [
+        "pkg:golang/google.golang.org/grpc@v1.31.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+      "dependsOn": [
+        "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/google.golang.org/appengine@v1.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/api@v0.30.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+      "dependsOn": [
+        "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+        "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+        "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+        "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+      "dependsOn": [
+        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+        "pkg:golang/github.com/google/renameio@v0.1.0",
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/go.opencensus.io@v0.22.4",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+      "dependsOn": [
+        "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+        "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+        "pkg:golang/github.com/goccy/go-json@v0.10.2",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+        "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+        "pkg:golang/github.com/go-playground/locales@v0.14.1",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+        "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+        "pkg:golang/golang.org/x/arch@v0.3.0",
+        "pkg:golang/golang.org/x/crypto@v0.9.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "dependsOn": [
+        "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/pty@v1.1.1",
+        "pkg:golang/github.com/creack/pty@v1.1.9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+        "pkg:golang/google.golang.org/appengine@v1.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/api@v0.26.1",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/k8s.io/apimachinery@v0.26.1",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
+      "dependsOn": [
+        "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/kr/text@v0.2.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+        "pkg:golang/github.com/onsi/gomega@v1.23.0",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/client-go@v0.26.1",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+        "pkg:golang/github.com/imdario/mergo@v0.3.6",
+        "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+        "pkg:golang/golang.org/x/term@v0.8.0",
+        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/k8s.io/api@v0.26.1",
+        "pkg:golang/k8s.io/apimachinery@v0.26.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/google/btree@v1.0.1",
+        "pkg:golang/github.com/josharian/intern@v1.0.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/moby/spdystream@v0.2.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+      "dependsOn": [
+        "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/google/uuid@v1.1.2",
+        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+        "pkg:golang/github.com/onsi/gomega@v1.23.0",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/github.com/stretchr/testify@v1.8.3",
+        "pkg:golang/google.golang.org/protobuf@v1.30.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1",
+        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+        "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+        "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/golang.org/x/mod@v0.8.0",
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/golang.org/x/text@v0.9.0",
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/k8s.io/klog/v2@v2.80.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "pkg:golang/github.com/google/gofuzz@v1.1.0",
+        "pkg:golang/github.com/json-iterator/go@v1.1.12",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+      ]
+    },
+    {
+      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.10.0",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@v1.4.4",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.6.0",
+        "pkg:golang/rsc.io/quote/v3@v3.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
+      "dependsOn": [
+        "pkg:golang/rsc.io/sampler@v1.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/text@v0.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.10.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+      "dependsOn": [
+        "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/btree@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/pretty@v0.3.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/renameio@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+      "dependsOn": [
+        "pkg:golang/github.com/chzyer/logex@v1.1.10",
+        "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+        "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+        "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+        "pkg:golang/golang.org/x/sys@v0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@v0.65.0",
+        "pkg:golang/github.com/golang/protobuf@v1.5.2",
+        "pkg:golang/github.com/google/go-cmp@v0.5.9",
+        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+        "pkg:golang/golang.org/x/sys@v0.8.0",
+        "pkg:golang/google.golang.org/api@v0.30.0",
+        "pkg:golang/google.golang.org/appengine@v1.6.7",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+        "pkg:golang/google.golang.org/grpc@v1.31.0",
+        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+        "pkg:golang/golang.org/x/tools@v0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/client9/misspell@v0.3.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/rsc.io/sampler@v1.3.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.9.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.8.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+      "dependsOn": []
+    }
+  ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
@@ -1,2085 +1,1369 @@
 {
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-      "group": "github.com/rhecosystemappeng/saasi",
-      "name": "deployer",
-      "version": "v0.0.0",
-      "purl": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+      "group" : "github.com/rhecosystemappeng/saasi",
+      "name" : "deployer",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0"
     }
   },
-  "components": [
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-      "group": "github.com/stretchr",
-      "name": "testify",
-      "version": "v1.8.3",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.8.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "group": "github.com/davecgh",
-      "name": "go-spew",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "group": "github.com/pmezard",
-      "name": "go-difflib",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "group": "github.com/stretchr",
-      "name": "objx",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-      "group": "gopkg.in",
-      "name": "yaml.v2",
-      "version": "v2.4.0",
-      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-      "group": "github.com/go-openapi",
-      "name": "jsonreference",
-      "version": "v0.20.0",
-      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-      "group": "github.com/go-openapi",
-      "name": "jsonpointer",
-      "version": "v0.19.5",
-      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/go.opencensus.io@v0.22.4",
-      "name": "go.opencensus.io",
-      "version": "v0.22.4",
-      "purl": "pkg:golang/go.opencensus.io@v0.22.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-      "group": "github.com/golang",
-      "name": "groupcache",
-      "version": "v0.0.0-20210331224755-41bb18bfe9da",
-      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-      "group": "github.com/golang",
-      "name": "protobuf",
-      "version": "v1.5.2",
-      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-      "group": "github.com/google",
-      "name": "go-cmp",
-      "version": "v0.5.9",
-      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0",
-      "group": "golang.org/x",
-      "name": "net",
-      "version": "v0.10.0",
-      "purl": "pkg:golang/golang.org/x/net@v0.10.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-      "group": "golang.org/x",
-      "name": "sys",
-      "version": "v0.8.0",
-      "purl": "pkg:golang/golang.org/x/sys@v0.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0",
-      "group": "golang.org/x",
-      "name": "text",
-      "version": "v0.9.0",
-      "purl": "pkg:golang/golang.org/x/text@v0.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-      "group": "google.golang.org",
-      "name": "genproto",
-      "version": "v0.0.0-20201019141844-1ed22bb0c154",
-      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
-      "group": "google.golang.org",
-      "name": "grpc",
-      "version": "v1.31.0",
-      "purl": "pkg:golang/google.golang.org/grpc@v1.31.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-      "group": "k8s.io/klog",
-      "name": "v2",
-      "version": "v2.80.1",
-      "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-      "group": "golang.org/x",
-      "name": "image",
-      "version": "v0.0.0-20190802002840-cff245a6509b",
-      "purl": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-      "group": "github.com/mailru",
-      "name": "easyjson",
-      "version": "v0.7.6",
-      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-      "group": "github.com/josharian",
-      "name": "intern",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-      "group": "github.com/cncf/udpa",
-      "name": "go",
-      "version": "v0.0.0-20191209042840-269d4d468f6f",
-      "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-      "group": "github.com/envoyproxy",
-      "name": "protoc-gen-validate",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-      "group": "cloud.google.com/go",
-      "name": "bigquery",
-      "version": "v1.8.0",
-      "purl": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-      "group": "cloud.google.com",
-      "name": "go",
-      "version": "v0.65.0",
-      "purl": "pkg:golang/cloud.google.com/go@v0.65.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-      "group": "cloud.google.com/go",
-      "name": "storage",
-      "version": "v1.10.0",
-      "purl": "pkg:golang/cloud.google.com/go/storage@v1.10.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-      "group": "github.com/googleapis/gax-go",
-      "name": "v2",
-      "version": "v2.0.5",
-      "purl": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-      "group": "golang.org/x",
-      "name": "exp",
-      "version": "v0.0.0-20200224162631-6cc2880d07d6",
-      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-      "group": "golang.org/x",
-      "name": "lint",
-      "version": "v0.0.0-20200302205851-738671d3881b",
-      "purl": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-      "group": "golang.org/x",
-      "name": "tools",
-      "version": "v0.6.0",
-      "purl": "pkg:golang/golang.org/x/tools@v0.6.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/api@v0.30.0",
-      "group": "google.golang.org",
-      "name": "api",
-      "version": "v0.30.0",
-      "purl": "pkg:golang/google.golang.org/api@v0.30.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-      "group": "gopkg.in",
-      "name": "check.v1",
-      "version": "v1.0.0-20200227125254-8fa46927fb4f",
-      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "group": "golang.org/x",
-      "name": "xerrors",
-      "version": "v0.0.0-20200804184101-5ec99f83aff1",
-      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-      "group": "github.com/emicklei/go-restful",
-      "name": "v3",
-      "version": "v3.9.0",
-      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-      "group": "github.com/gin-gonic",
-      "name": "gin",
-      "version": "v1.9.1",
-      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-      "group": "github.com/go-openapi",
-      "name": "swag",
-      "version": "v0.19.14",
-      "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-      "group": "github.com/gogo",
-      "name": "protobuf",
-      "version": "v1.3.2",
-      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-      "group": "github.com/google",
-      "name": "gofuzz",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2",
-      "group": "github.com/google",
-      "name": "uuid",
-      "version": "v1.1.2",
-      "purl": "pkg:golang/github.com/google/uuid@v1.1.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-      "group": "github.com/imdario",
-      "name": "mergo",
-      "version": "v0.3.6",
-      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-      "group": "github.com/json-iterator",
-      "name": "go",
-      "version": "v1.1.12",
-      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
-      "group": "github.com/kr",
-      "name": "pretty",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/kr/pretty@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0",
-      "group": "github.com/kr",
-      "name": "text",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/kr/text@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-      "group": "github.com/modern-go",
-      "name": "concurrent",
-      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-      "group": "github.com/modern-go",
-      "name": "reflect2",
-      "version": "v1.0.2",
-      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-      "group": "github.com/munnerz",
-      "name": "goautoneg",
-      "version": "v0.0.0-20191010083416-a7dc8b61c822",
-      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-      "group": "github.com/rogpeppe",
-      "name": "go-internal",
-      "version": "v1.9.0",
-      "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-      "group": "github.com/spf13",
-      "name": "pflag",
-      "version": "v1.0.5",
-      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-      "group": "golang.org/x",
-      "name": "oauth2",
-      "version": "v0.0.0-20220223155221-ee480838109b",
-      "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0",
-      "group": "golang.org/x",
-      "name": "term",
-      "version": "v0.8.0",
-      "purl": "pkg:golang/golang.org/x/term@v0.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-      "group": "golang.org/x",
-      "name": "time",
-      "version": "v0.0.0-20220210224613-90d013bbcef8",
-      "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-      "group": "google.golang.org",
-      "name": "appengine",
-      "version": "v1.6.7",
-      "purl": "pkg:golang/google.golang.org/appengine@v1.6.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-      "group": "google.golang.org",
-      "name": "protobuf",
-      "version": "v1.30.0",
-      "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-      "group": "gopkg.in",
-      "name": "inf.v0",
-      "version": "v0.9.1",
-      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "group": "gopkg.in",
-      "name": "yaml.v3",
-      "version": "v3.0.1",
-      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/api@v0.26.1",
-      "group": "k8s.io",
-      "name": "api",
-      "version": "v0.26.1",
-      "purl": "pkg:golang/k8s.io/api@v0.26.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
-      "group": "k8s.io",
-      "name": "apimachinery",
-      "version": "v0.26.1",
-      "purl": "pkg:golang/k8s.io/apimachinery@v0.26.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1",
-      "group": "k8s.io",
-      "name": "client-go",
-      "version": "v0.26.1",
-      "purl": "pkg:golang/k8s.io/client-go@v0.26.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-      "group": "k8s.io",
-      "name": "kube-openapi",
-      "version": "v0.0.0-20221012153701-172d655c2280",
-      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-      "group": "k8s.io",
-      "name": "utils",
-      "version": "v0.0.0-20221107191617-1a15be271d1d",
-      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-      "group": "sigs.k8s.io",
-      "name": "json",
-      "version": "v0.0.0-20220713155537-f223a00ba0e2",
-      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-      "group": "sigs.k8s.io/structured-merge-diff",
-      "name": "v4",
-      "version": "v4.2.3",
-      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-      "group": "sigs.k8s.io",
-      "name": "yaml",
-      "version": "v1.3.0",
-      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-      "group": "golang.org/x",
-      "name": "mod",
-      "version": "v0.8.0",
-      "purl": "pkg:golang/golang.org/x/mod@v0.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-      "group": "golang.org/x",
-      "name": "crypto",
-      "version": "v0.9.0",
-      "purl": "pkg:golang/golang.org/x/crypto@v0.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-      "group": "github.com/kisielk",
-      "name": "errcheck",
-      "version": "v1.5.0",
-      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-      "group": "github.com/kisielk",
-      "name": "gotool",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-      "group": "honnef.co/go",
-      "name": "tools",
-      "version": "v0.0.1-2020.1.4",
-      "purl": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/mock@v1.4.4",
-      "group": "github.com/golang",
-      "name": "mock",
-      "version": "v1.4.4",
-      "purl": "pkg:golang/github.com/golang/mock@v1.4.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
-      "group": "rsc.io/quote",
-      "name": "v3",
-      "version": "v3.1.0",
-      "purl": "pkg:golang/rsc.io/quote/v3@v3.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-      "group": "github.com/niemeyer",
-      "name": "pretty",
-      "version": "v0.0.0-20200227124842-a10e7caefd8e",
-      "purl": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-      "group": "golang.org/x",
-      "name": "mobile",
-      "version": "v0.0.0-20190719004257-d2bd2a29d028",
-      "purl": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-      "group": "github.com/armon",
-      "name": "go-socks5",
-      "version": "v0.0.0-20160902184237-e75332964ef5",
-      "purl": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-      "group": "github.com/elazarl",
-      "name": "goproxy",
-      "version": "v0.0.0-20180725130230-947c36da3153",
-      "purl": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-      "group": "github.com/evanphx",
-      "name": "json-patch",
-      "version": "v4.12.0+incompatible",
-      "purl": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-      "group": "github.com/moby",
-      "name": "spdystream",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/moby/spdystream@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-      "group": "github.com/mxk",
-      "name": "go-flowrate",
-      "version": "v0.0.0-20140419014527-cca7078d478f",
-      "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-      "group": "github.com/onsi/ginkgo",
-      "name": "v2",
-      "version": "v2.4.0",
-      "purl": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
-      "group": "github.com/onsi",
-      "name": "gomega",
-      "version": "v1.23.0",
-      "purl": "pkg:golang/github.com/onsi/gomega@v1.23.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
-      "group": "github.com/pkg",
-      "name": "errors",
-      "version": "v0.9.1",
-      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
-      "group": "github.com/google/martian",
-      "name": "v3",
-      "version": "v3.0.0",
-      "purl": "pkg:golang/github.com/google/martian/v3@v3.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-      "group": "github.com/envoyproxy",
-      "name": "go-control-plane",
-      "version": "v0.9.4",
-      "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-      "group": "github.com/census-instrumentation",
-      "name": "opencensus-proto",
-      "version": "v0.2.1",
-      "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-      "group": "github.com/prometheus",
-      "name": "client_model",
-      "version": "v0.0.0-20190812154241-14fe0d1b01d4",
-      "purl": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-      "group": "github.com/bytedance",
-      "name": "sonic",
-      "version": "v1.9.1",
-      "purl": "pkg:golang/github.com/bytedance/sonic@v1.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "group": "github.com/gin-contrib",
-      "name": "sse",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-      "group": "github.com/go-playground/validator",
-      "name": "v10",
-      "version": "v10.14.0",
-      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-      "group": "github.com/goccy",
-      "name": "go-json",
-      "version": "v0.10.2",
-      "purl": "pkg:golang/github.com/goccy/go-json@v0.10.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-      "group": "github.com/mattn",
-      "name": "go-isatty",
-      "version": "v0.0.19",
-      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-      "group": "github.com/pelletier/go-toml",
-      "name": "v2",
-      "version": "v2.0.8",
-      "purl": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-      "group": "github.com/ugorji/go",
-      "name": "codec",
-      "version": "v1.2.11",
-      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-      "group": "github.com/chenzhuoyu",
-      "name": "base64x",
-      "version": "v0.0.0-20221115062448-fe3a3abad311",
-      "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-      "group": "github.com/gabriel-vasile",
-      "name": "mimetype",
-      "version": "v1.4.2",
-      "purl": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-      "group": "github.com/go-playground",
-      "name": "locales",
-      "version": "v0.14.1",
-      "purl": "pkg:golang/github.com/go-playground/locales@v0.14.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-      "group": "github.com/go-playground",
-      "name": "universal-translator",
-      "version": "v0.18.1",
-      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-      "group": "github.com/klauspost/cpuid",
-      "name": "v2",
-      "version": "v2.2.4",
-      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-      "group": "github.com/leodido",
-      "name": "go-urn",
-      "version": "v1.2.4",
-      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-      "group": "github.com/twitchyliquid64",
-      "name": "golang-asm",
-      "version": "v0.15.1",
-      "purl": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-      "group": "golang.org/x",
-      "name": "arch",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/golang.org/x/arch@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-      "group": "golang.org/x",
-      "name": "sync",
-      "version": "v0.0.0-20201020160332-67f06af15bc9",
-      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-      "group": "github.com/gregjones",
-      "name": "httpcache",
-      "version": "v0.0.0-20180305231024-9cad4c3443a7",
-      "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-      "group": "github.com/peterbourgon",
-      "name": "diskv",
-      "version": "v2.0.1+incompatible",
-      "purl": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1",
-      "group": "github.com/google",
-      "name": "btree",
-      "version": "v1.0.1",
-      "purl": "pkg:golang/github.com/google/btree@v1.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-      "group": "github.com/pkg",
-      "name": "diff",
-      "version": "v0.0.0-20210226163009-20ebb0f2a09e",
-      "purl": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "group": "github.com/hashicorp",
-      "name": "golang-lru",
-      "version": "v0.5.1",
-      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-      "group": "github.com/burntsushi",
-      "name": "toml",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/burntsushi/toml@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/renameio@v0.1.0",
-      "group": "github.com/google",
-      "name": "renameio",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/google/renameio@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-      "group": "github.com/google",
-      "name": "pprof",
-      "version": "v0.0.0-20200708004538-1a94d8640e99",
-      "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
-      "group": "github.com/chzyer",
-      "name": "logex",
-      "version": "v1.1.10",
-      "purl": "pkg:golang/github.com/chzyer/logex@v1.1.10"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-      "group": "github.com/chzyer",
-      "name": "readline",
-      "version": "v0.0.0-20180603132655-2972be24d48e",
-      "purl": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-      "group": "github.com/chzyer",
-      "name": "test",
-      "version": "v0.0.0-20180213035817-a1ea475d72b1",
-      "purl": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-      "group": "github.com/ianlancetaylor",
-      "name": "demangle",
-      "version": "v0.0.0-20181102032728-5e5cf60278f6",
-      "purl": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-      "group": "cloud.google.com/go",
-      "name": "pubsub",
-      "version": "v1.3.1",
-      "purl": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-      "group": "github.com/nytimes",
-      "name": "gziphandler",
-      "version": "v0.0.0-20170623195520-56545f4a5d46",
-      "purl": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-      "group": "github.com/asaskevich",
-      "name": "govalidator",
-      "version": "v0.0.0-20190424111038-f61b66f89f4a",
-      "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-      "group": "github.com/mitchellh",
-      "name": "mapstructure",
-      "version": "v1.1.2",
-      "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-      "group": "k8s.io",
-      "name": "gengo",
-      "version": "v0.0.0-20210813121822-485abfe95c7c",
-      "purl": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-      "group": "github.com/puerkitobio",
-      "name": "purell",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-      "group": "github.com/puerkitobio",
-      "name": "urlesc",
-      "version": "v0.0.0-20170810143723-de5bf2ad4578",
-      "purl": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-      "group": "cloud.google.com/go",
-      "name": "datastore",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-      "group": "github.com/creack",
-      "name": "pty",
-      "version": "v1.1.9",
-      "purl": "pkg:golang/github.com/creack/pty@v1.1.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-      "group": "github.com/golang",
-      "name": "glog",
-      "version": "v0.0.0-20160126235308-23def4e6c14b",
-      "purl": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/rsc.io/sampler@v1.3.0",
-      "group": "rsc.io",
-      "name": "sampler",
-      "version": "v1.3.0",
-      "purl": "pkg:golang/rsc.io/sampler@v1.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-      "group": "dmitri.shuralyov.com/gpu",
-      "name": "mtl",
-      "version": "v0.0.0-20190408044501-666a987793e9",
-      "purl": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-      "group": "github.com/burntsushi",
-      "name": "xgb",
-      "version": "v0.0.0-20160522181843-27f122750802",
-      "purl": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-      "group": "github.com/go-gl/glfw/v3.3",
-      "name": "glfw",
-      "version": "v0.0.0-20200222043503-6f7a984d4dc4",
-      "purl": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-      "group": "github.com/google",
-      "name": "martian",
-      "version": "v2.1.0+incompatible",
-      "purl": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-      "group": "github.com/jstemmer",
-      "name": "go-junit-report",
-      "version": "v0.9.1",
-      "purl": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-      "group": "rsc.io",
-      "name": "binaryregexp",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-      "group": "github.com/stoewer",
-      "name": "go-strcase",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-      "group": "github.com/docopt",
-      "name": "docopt-go",
-      "version": "v0.0.0-20180111231733-ee0de3bc6815",
-      "purl": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-      "group": "gopkg.in",
-      "name": "errgo.v2",
-      "version": "v2.1.0",
-      "purl": "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-        "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/imdario/mergo@v0.3.6",
-        "pkg:golang/github.com/josharian/intern@v1.0.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/kr/pretty@v0.3.1",
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/term@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/google.golang.org/appengine@v1.6.7",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/k8s.io/api@v0.26.1",
-        "pkg:golang/k8s.io/apimachinery@v0.26.1",
-        "pkg:golang/k8s.io/client-go@v0.26.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/stretchr/objx@v0.1.0",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-      "dependsOn": [
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/go.opencensus.io@v0.22.4",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/net@v0.10.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.9.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/text@v0.9.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/grpc@v1.31.0",
-      "dependsOn": [
-        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-        "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-        "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-      "dependsOn": [
-        "pkg:golang/github.com/josharian/intern@v1.0.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-      "dependsOn": [
-        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-        "pkg:golang/github.com/golang/mock@v1.4.4",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/btree@v1.0.1",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-        "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-        "pkg:golang/go.opencensus.io@v0.22.4",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-        "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-      "dependsOn": [
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-      "dependsOn": [
-        "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-        "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-        "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-        "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-        "pkg:golang/golang.org/x/mod@v0.8.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/google.golang.org/appengine@v1.6.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/api@v0.30.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/go.opencensus.io@v0.22.4",
-        "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/appengine@v1.6.7",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0",
-        "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
-      "dependsOn": [
-        "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-        "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-        "pkg:golang/github.com/goccy/go-json@v0.10.2",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-        "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-        "pkg:golang/github.com/go-playground/locales@v0.14.1",
-        "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-        "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-        "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-        "pkg:golang/golang.org/x/arch@v0.3.0",
-        "pkg:golang/golang.org/x/crypto@v0.9.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-      "dependsOn": [
-        "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/text@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/creack/pty@v1.1.9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/google.golang.org/appengine@v1.6.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/term@v0.8.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/api@v0.26.1",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/k8s.io/apimachinery@v0.26.1",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/apimachinery@v0.26.1",
-      "dependsOn": [
-        "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/moby/spdystream@v0.2.0",
-        "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/kr/text@v0.2.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-        "pkg:golang/github.com/onsi/gomega@v1.23.0",
-        "pkg:golang/github.com/pkg/errors@v0.9.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/client-go@v0.26.1",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-        "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-        "pkg:golang/github.com/imdario/mergo@v0.3.6",
-        "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/term@v0.8.0",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/k8s.io/api@v0.26.1",
-        "pkg:golang/k8s.io/apimachinery@v0.26.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/google/btree@v1.0.1",
-        "pkg:golang/github.com/josharian/intern@v1.0.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/moby/spdystream@v0.2.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-        "pkg:golang/github.com/pkg/errors@v0.9.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/google.golang.org/appengine@v1.6.7",
-        "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-      "dependsOn": [
-        "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-        "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-        "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-        "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-        "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/google/uuid@v1.1.2",
-        "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-        "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-        "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-        "pkg:golang/github.com/onsi/gomega@v1.23.0",
-        "pkg:golang/github.com/spf13/pflag@v1.0.5",
-        "pkg:golang/github.com/stretchr/testify@v1.8.3",
-        "pkg:golang/google.golang.org/protobuf@v1.30.0",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-        "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1",
-        "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-        "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-        "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-        "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-        "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-        "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/golang.org/x/mod@v0.8.0",
-        "pkg:golang/golang.org/x/net@v0.10.0",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/text@v0.9.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/k8s.io/klog/v2@v2.80.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-        "pkg:golang/github.com/google/gofuzz@v1.1.0",
-        "pkg:golang/github.com/json-iterator/go@v1.1.12",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-      ]
-    },
-    {
-      "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-      "dependsOn": [
-        "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-        "pkg:golang/github.com/google/renameio@v0.1.0",
-        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-        "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-        "pkg:golang/golang.org/x/mod@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/mock@v1.4.4",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/rsc.io/quote/v3@v3.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/rsc.io/quote/v3@v3.1.0",
-      "dependsOn": [
-        "pkg:golang/rsc.io/sampler@v1.3.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/text@v0.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/gomega@v1.23.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/martian/v3@v3.0.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.10.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
-      "dependsOn": [
-        "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-        "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
-        "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/btree@v1.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/burntsushi/toml@v0.3.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/renameio@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-      "dependsOn": [
-        "pkg:golang/github.com/chzyer/logex@v1.1.10",
-        "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-        "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-        "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-        "pkg:golang/golang.org/x/sys@v0.8.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/chzyer/logex@v1.1.10",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/go.opencensus.io@v0.22.4",
-        "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-        "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-      "dependsOn": [
-        "pkg:golang/cloud.google.com/go@v0.65.0",
-        "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-        "pkg:golang/github.com/golang/protobuf@v1.5.2",
-        "pkg:golang/github.com/google/go-cmp@v0.5.9",
-        "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-        "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-        "pkg:golang/golang.org/x/sys@v0.8.0",
-        "pkg:golang/golang.org/x/tools@v0.6.0",
-        "pkg:golang/google.golang.org/api@v0.30.0",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-        "pkg:golang/google.golang.org/grpc@v1.31.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/rsc.io/sampler@v1.3.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.9.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/rsc.io/binaryregexp@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.8.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/pretty@v0.3.1",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-      ]
-    }
-  ]
+  "components" : [ {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
+    "group" : "github.com/stretchr",
+    "name" : "testify",
+    "version" : "v1.8.3",
+    "purl" : "pkg:golang/github.com/stretchr/testify@v1.8.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "group" : "github.com/davecgh",
+    "name" : "go-spew",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "group" : "github.com/pmezard",
+    "name" : "go-difflib",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "group" : "github.com/stretchr",
+    "name" : "objx",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+    "group" : "gopkg.in",
+    "name" : "yaml.v2",
+    "version" : "v2.4.0",
+    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+    "group" : "gopkg.in",
+    "name" : "yaml.v3",
+    "version" : "v3.0.1",
+    "purl" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/go.opencensus.io@v0.22.4",
+    "name" : "go.opencensus.io",
+    "version" : "v0.22.4",
+    "purl" : "pkg:golang/go.opencensus.io@v0.22.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
+    "group" : "github.com/golang",
+    "name" : "protobuf",
+    "version" : "v1.5.2",
+    "purl" : "pkg:golang/github.com/golang/protobuf@v1.5.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
+    "group" : "github.com/google",
+    "name" : "go-cmp",
+    "version" : "v0.5.9",
+    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "group" : "github.com/hashicorp",
+    "name" : "golang-lru",
+    "version" : "v0.5.1",
+    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/net@v0.10.0",
+    "group" : "golang.org/x",
+    "name" : "net",
+    "version" : "v0.10.0",
+    "purl" : "pkg:golang/golang.org/x/net@v0.10.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+    "group" : "google.golang.org",
+    "name" : "genproto",
+    "version" : "v0.0.0-20201019141844-1ed22bb0c154",
+    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
+    "group" : "google.golang.org",
+    "name" : "grpc",
+    "version" : "v1.31.0",
+    "purl" : "pkg:golang/google.golang.org/grpc@v1.31.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+    "group" : "github.com/golang",
+    "name" : "groupcache",
+    "version" : "v0.0.0-20210331224755-41bb18bfe9da",
+    "purl" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
+    "group" : "golang.org/x",
+    "name" : "sys",
+    "version" : "v0.8.0",
+    "purl" : "pkg:golang/golang.org/x/sys@v0.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/text@v0.9.0",
+    "group" : "golang.org/x",
+    "name" : "text",
+    "version" : "v0.9.0",
+    "purl" : "pkg:golang/golang.org/x/text@v0.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+    "group" : "github.com/go-openapi",
+    "name" : "jsonreference",
+    "version" : "v0.20.0",
+    "purl" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+    "group" : "github.com/go-openapi",
+    "name" : "jsonpointer",
+    "version" : "v0.19.5",
+    "purl" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
+    "group" : "k8s.io/klog",
+    "name" : "v2",
+    "version" : "v2.80.1",
+    "purl" : "pkg:golang/k8s.io/klog/v2@v2.80.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+    "group" : "golang.org/x",
+    "name" : "image",
+    "version" : "v0.0.0-20190802002840-cff245a6509b",
+    "purl" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+    "group" : "github.com/mailru",
+    "name" : "easyjson",
+    "version" : "v0.7.6",
+    "purl" : "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
+    "group" : "github.com/josharian",
+    "name" : "intern",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/josharian/intern@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+    "group" : "github.com/cncf/udpa",
+    "name" : "go",
+    "version" : "v0.0.0-20191209042840-269d4d468f6f",
+    "purl" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+    "group" : "github.com/envoyproxy",
+    "name" : "protoc-gen-validate",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+    "group" : "cloud.google.com/go",
+    "name" : "bigquery",
+    "version" : "v1.8.0",
+    "purl" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
+    "group" : "cloud.google.com",
+    "name" : "go",
+    "version" : "v0.65.0",
+    "purl" : "pkg:golang/cloud.google.com/go@v0.65.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+    "group" : "cloud.google.com/go",
+    "name" : "storage",
+    "version" : "v1.10.0",
+    "purl" : "pkg:golang/cloud.google.com/go/storage@v1.10.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+    "group" : "github.com/googleapis/gax-go",
+    "name" : "v2",
+    "version" : "v2.0.5",
+    "purl" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
+    "group" : "golang.org/x",
+    "name" : "tools",
+    "version" : "v0.6.0",
+    "purl" : "pkg:golang/golang.org/x/tools@v0.6.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/api@v0.30.0",
+    "group" : "google.golang.org",
+    "name" : "api",
+    "version" : "v0.30.0",
+    "purl" : "pkg:golang/google.golang.org/api@v0.30.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+    "group" : "golang.org/x",
+    "name" : "exp",
+    "version" : "v0.0.0-20200224162631-6cc2880d07d6",
+    "purl" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
+    "group" : "golang.org/x",
+    "name" : "mod",
+    "version" : "v0.8.0",
+    "purl" : "pkg:golang/golang.org/x/mod@v0.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+    "group" : "honnef.co/go",
+    "name" : "tools",
+    "version" : "v0.0.1-2020.1.4",
+    "purl" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+    "group" : "cloud.google.com/go",
+    "name" : "pubsub",
+    "version" : "v1.3.1",
+    "purl" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
+    "group" : "google.golang.org",
+    "name" : "appengine",
+    "version" : "v1.6.7",
+    "purl" : "pkg:golang/google.golang.org/appengine@v1.6.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+    "group" : "golang.org/x",
+    "name" : "lint",
+    "version" : "v0.0.0-20200302205851-738671d3881b",
+    "purl" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+    "group" : "gopkg.in",
+    "name" : "check.v1",
+    "version" : "v1.0.0-20200227125254-8fa46927fb4f",
+    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+    "group" : "github.com/emicklei/go-restful",
+    "name" : "v3",
+    "version" : "v3.9.0",
+    "purl" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+    "group" : "github.com/gin-gonic",
+    "name" : "gin",
+    "version" : "v1.9.1",
+    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+    "group" : "github.com/go-openapi",
+    "name" : "swag",
+    "version" : "v0.19.14",
+    "purl" : "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+    "group" : "github.com/gogo",
+    "name" : "protobuf",
+    "version" : "v1.3.2",
+    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
+    "group" : "github.com/google",
+    "name" : "gofuzz",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/google/gofuzz@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
+    "group" : "github.com/google",
+    "name" : "uuid",
+    "version" : "v1.1.2",
+    "purl" : "pkg:golang/github.com/google/uuid@v1.1.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
+    "group" : "github.com/imdario",
+    "name" : "mergo",
+    "version" : "v0.3.6",
+    "purl" : "pkg:golang/github.com/imdario/mergo@v0.3.6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
+    "group" : "github.com/json-iterator",
+    "name" : "go",
+    "version" : "v1.1.12",
+    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.12"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
+    "group" : "github.com/kr",
+    "name" : "pretty",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/kr/pretty@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/text@v0.2.0",
+    "group" : "github.com/kr",
+    "name" : "text",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/kr/text@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+    "group" : "github.com/modern-go",
+    "name" : "concurrent",
+    "version" : "v0.0.0-20180306012644-bacd9c7ef1dd",
+    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+    "group" : "github.com/modern-go",
+    "name" : "reflect2",
+    "version" : "v1.0.2",
+    "purl" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+    "group" : "github.com/munnerz",
+    "name" : "goautoneg",
+    "version" : "v0.0.0-20191010083416-a7dc8b61c822",
+    "purl" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+    "group" : "github.com/rogpeppe",
+    "name" : "go-internal",
+    "version" : "v1.9.0",
+    "purl" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
+    "group" : "github.com/spf13",
+    "name" : "pflag",
+    "version" : "v1.0.5",
+    "purl" : "pkg:golang/github.com/spf13/pflag@v1.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+    "group" : "golang.org/x",
+    "name" : "oauth2",
+    "version" : "v0.0.0-20220223155221-ee480838109b",
+    "purl" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/term@v0.8.0",
+    "group" : "golang.org/x",
+    "name" : "term",
+    "version" : "v0.8.0",
+    "purl" : "pkg:golang/golang.org/x/term@v0.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+    "group" : "golang.org/x",
+    "name" : "time",
+    "version" : "v0.0.0-20220210224613-90d013bbcef8",
+    "purl" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
+    "group" : "google.golang.org",
+    "name" : "protobuf",
+    "version" : "v1.30.0",
+    "purl" : "pkg:golang/google.golang.org/protobuf@v1.30.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+    "group" : "gopkg.in",
+    "name" : "inf.v0",
+    "version" : "v0.9.1",
+    "purl" : "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/api@v0.26.1",
+    "group" : "k8s.io",
+    "name" : "api",
+    "version" : "v0.26.1",
+    "purl" : "pkg:golang/k8s.io/api@v0.26.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
+    "group" : "k8s.io",
+    "name" : "apimachinery",
+    "version" : "v0.26.1",
+    "purl" : "pkg:golang/k8s.io/apimachinery@v0.26.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
+    "group" : "k8s.io",
+    "name" : "client-go",
+    "version" : "v0.26.1",
+    "purl" : "pkg:golang/k8s.io/client-go@v0.26.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+    "group" : "k8s.io",
+    "name" : "kube-openapi",
+    "version" : "v0.0.0-20221012153701-172d655c2280",
+    "purl" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+    "group" : "k8s.io",
+    "name" : "utils",
+    "version" : "v0.0.0-20221107191617-1a15be271d1d",
+    "purl" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+    "group" : "sigs.k8s.io",
+    "name" : "json",
+    "version" : "v0.0.0-20220713155537-f223a00ba0e2",
+    "purl" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+    "group" : "sigs.k8s.io/structured-merge-diff",
+    "name" : "v4",
+    "version" : "v4.2.3",
+    "purl" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+    "group" : "sigs.k8s.io",
+    "name" : "yaml",
+    "version" : "v1.3.0",
+    "purl" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "group" : "golang.org/x",
+    "name" : "xerrors",
+    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
+    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
+    "group" : "golang.org/x",
+    "name" : "crypto",
+    "version" : "v0.9.0",
+    "purl" : "pkg:golang/golang.org/x/crypto@v0.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+    "group" : "github.com/kisielk",
+    "name" : "errcheck",
+    "version" : "v1.5.0",
+    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "group" : "github.com/kisielk",
+    "name" : "gotool",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
+    "group" : "github.com/golang",
+    "name" : "mock",
+    "version" : "v1.4.4",
+    "purl" : "pkg:golang/github.com/golang/mock@v1.4.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
+    "group" : "rsc.io/quote",
+    "name" : "v3",
+    "version" : "v3.1.0",
+    "purl" : "pkg:golang/rsc.io/quote/v3@v3.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+    "group" : "golang.org/x",
+    "name" : "sync",
+    "version" : "v0.0.0-20201020160332-67f06af15bc9",
+    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+    "group" : "github.com/niemeyer",
+    "name" : "pretty",
+    "version" : "v0.0.0-20200227124842-a10e7caefd8e",
+    "purl" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+    "group" : "golang.org/x",
+    "name" : "mobile",
+    "version" : "v0.0.0-20190719004257-d2bd2a29d028",
+    "purl" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+    "group" : "github.com/armon",
+    "name" : "go-socks5",
+    "version" : "v0.0.0-20160902184237-e75332964ef5",
+    "purl" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+    "group" : "github.com/elazarl",
+    "name" : "goproxy",
+    "version" : "v0.0.0-20180725130230-947c36da3153",
+    "purl" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+    "group" : "github.com/evanphx",
+    "name" : "json-patch",
+    "version" : "v4.12.0+incompatible",
+    "purl" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
+    "group" : "github.com/moby",
+    "name" : "spdystream",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/moby/spdystream@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+    "group" : "github.com/mxk",
+    "name" : "go-flowrate",
+    "version" : "v0.0.0-20140419014527-cca7078d478f",
+    "purl" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+    "group" : "github.com/onsi/ginkgo",
+    "name" : "v2",
+    "version" : "v2.4.0",
+    "purl" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
+    "group" : "github.com/onsi",
+    "name" : "gomega",
+    "version" : "v1.23.0",
+    "purl" : "pkg:golang/github.com/onsi/gomega@v1.23.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
+    "group" : "github.com/pkg",
+    "name" : "errors",
+    "version" : "v0.9.1",
+    "purl" : "pkg:golang/github.com/pkg/errors@v0.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
+    "group" : "github.com/google/martian",
+    "name" : "v3",
+    "version" : "v3.0.0",
+    "purl" : "pkg:golang/github.com/google/martian/v3@v3.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+    "group" : "github.com/envoyproxy",
+    "name" : "go-control-plane",
+    "version" : "v0.9.4",
+    "purl" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+    "group" : "github.com/census-instrumentation",
+    "name" : "opencensus-proto",
+    "version" : "v0.2.1",
+    "purl" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+    "group" : "github.com/prometheus",
+    "name" : "client_model",
+    "version" : "v0.0.0-20190812154241-14fe0d1b01d4",
+    "purl" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+    "group" : "github.com/bytedance",
+    "name" : "sonic",
+    "version" : "v1.9.1",
+    "purl" : "pkg:golang/github.com/bytedance/sonic@v1.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "group" : "github.com/gin-contrib",
+    "name" : "sse",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+    "group" : "github.com/go-playground/validator",
+    "name" : "v10",
+    "version" : "v10.14.0",
+    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
+    "group" : "github.com/goccy",
+    "name" : "go-json",
+    "version" : "v0.10.2",
+    "purl" : "pkg:golang/github.com/goccy/go-json@v0.10.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+    "group" : "github.com/mattn",
+    "name" : "go-isatty",
+    "version" : "v0.0.19",
+    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+    "group" : "github.com/pelletier/go-toml",
+    "name" : "v2",
+    "version" : "v2.0.8",
+    "purl" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+    "group" : "github.com/ugorji/go",
+    "name" : "codec",
+    "version" : "v1.2.11",
+    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+    "group" : "github.com/chenzhuoyu",
+    "name" : "base64x",
+    "version" : "v0.0.0-20221115062448-fe3a3abad311",
+    "purl" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+    "group" : "github.com/gabriel-vasile",
+    "name" : "mimetype",
+    "version" : "v1.4.2",
+    "purl" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
+    "group" : "github.com/go-playground",
+    "name" : "locales",
+    "version" : "v0.14.1",
+    "purl" : "pkg:golang/github.com/go-playground/locales@v0.14.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+    "group" : "github.com/go-playground",
+    "name" : "universal-translator",
+    "version" : "v0.18.1",
+    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+    "group" : "github.com/klauspost/cpuid",
+    "name" : "v2",
+    "version" : "v2.2.4",
+    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+    "group" : "github.com/leodido",
+    "name" : "go-urn",
+    "version" : "v1.2.4",
+    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+    "group" : "github.com/twitchyliquid64",
+    "name" : "golang-asm",
+    "version" : "v0.15.1",
+    "purl" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
+    "group" : "golang.org/x",
+    "name" : "arch",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/golang.org/x/arch@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+    "group" : "github.com/gregjones",
+    "name" : "httpcache",
+    "version" : "v0.0.0-20180305231024-9cad4c3443a7",
+    "purl" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+    "group" : "github.com/peterbourgon",
+    "name" : "diskv",
+    "version" : "v2.0.1+incompatible",
+    "purl" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/btree@v1.0.1",
+    "group" : "github.com/google",
+    "name" : "btree",
+    "version" : "v1.0.1",
+    "purl" : "pkg:golang/github.com/google/btree@v1.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+    "group" : "gopkg.in",
+    "name" : "errgo.v2",
+    "version" : "v2.1.0",
+    "purl" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+    "group" : "github.com/pkg",
+    "name" : "diff",
+    "version" : "v0.0.0-20210226163009-20ebb0f2a09e",
+    "purl" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+    "group" : "github.com/burntsushi",
+    "name" : "toml",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/burntsushi/toml@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
+    "group" : "github.com/google",
+    "name" : "renameio",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/google/renameio@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+    "group" : "github.com/google",
+    "name" : "pprof",
+    "version" : "v0.0.0-20200708004538-1a94d8640e99",
+    "purl" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
+    "group" : "github.com/chzyer",
+    "name" : "logex",
+    "version" : "v1.1.10",
+    "purl" : "pkg:golang/github.com/chzyer/logex@v1.1.10"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+    "group" : "github.com/chzyer",
+    "name" : "readline",
+    "version" : "v0.0.0-20180603132655-2972be24d48e",
+    "purl" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+    "group" : "github.com/chzyer",
+    "name" : "test",
+    "version" : "v0.0.0-20180213035817-a1ea475d72b1",
+    "purl" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+    "group" : "github.com/ianlancetaylor",
+    "name" : "demangle",
+    "version" : "v0.0.0-20181102032728-5e5cf60278f6",
+    "purl" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+    "group" : "github.com/nytimes",
+    "name" : "gziphandler",
+    "version" : "v0.0.0-20170623195520-56545f4a5d46",
+    "purl" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+    "group" : "github.com/asaskevich",
+    "name" : "govalidator",
+    "version" : "v0.0.0-20190424111038-f61b66f89f4a",
+    "purl" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+    "group" : "github.com/mitchellh",
+    "name" : "mapstructure",
+    "version" : "v1.1.2",
+    "purl" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+    "group" : "k8s.io",
+    "name" : "gengo",
+    "version" : "v0.0.0-20210813121822-485abfe95c7c",
+    "purl" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+    "group" : "github.com/puerkitobio",
+    "name" : "purell",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+    "group" : "github.com/puerkitobio",
+    "name" : "urlesc",
+    "version" : "v0.0.0-20170810143723-de5bf2ad4578",
+    "purl" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+    "group" : "github.com/jstemmer",
+    "name" : "go-junit-report",
+    "version" : "v0.9.1",
+    "purl" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+    "group" : "cloud.google.com/go",
+    "name" : "datastore",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "group" : "github.com/kr",
+    "name" : "pty",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
+    "group" : "github.com/creack",
+    "name" : "pty",
+    "version" : "v1.1.9",
+    "purl" : "pkg:golang/github.com/creack/pty@v1.1.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+    "group" : "github.com/yuin",
+    "name" : "goldmark",
+    "version" : "v1.2.1",
+    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+    "group" : "github.com/golang",
+    "name" : "glog",
+    "version" : "v0.0.0-20160126235308-23def4e6c14b",
+    "purl" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
+    "group" : "github.com/client9",
+    "name" : "misspell",
+    "version" : "v0.3.4",
+    "purl" : "pkg:golang/github.com/client9/misspell@v0.3.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
+    "group" : "rsc.io",
+    "name" : "sampler",
+    "version" : "v1.3.0",
+    "purl" : "pkg:golang/rsc.io/sampler@v1.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+    "group" : "dmitri.shuralyov.com/gpu",
+    "name" : "mtl",
+    "version" : "v0.0.0-20190408044501-666a987793e9",
+    "purl" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+    "group" : "github.com/burntsushi",
+    "name" : "xgb",
+    "version" : "v0.0.0-20160522181843-27f122750802",
+    "purl" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+    "group" : "github.com/go-gl/glfw/v3.3",
+    "name" : "glfw",
+    "version" : "v0.0.0-20200222043503-6f7a984d4dc4",
+    "purl" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+    "group" : "github.com/go-gl",
+    "name" : "glfw",
+    "version" : "v0.0.0-20190409004039-e6da0acd62b1",
+    "purl" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+    "group" : "github.com/google",
+    "name" : "martian",
+    "version" : "v2.1.0+incompatible",
+    "purl" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+    "group" : "rsc.io",
+    "name" : "binaryregexp",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+    "group" : "github.com/stoewer",
+    "name" : "go-strcase",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+    "group" : "github.com/docopt",
+    "name" : "docopt-go",
+    "version" : "v0.0.0-20180111231733-ee0de3bc6815",
+    "purl" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
+  } ],
+  "dependencies" : [ {
+    "ref" : "pkg:golang/github.com/rhecosystemappeng/saasi/deployer@v0.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/gin-gonic/gin@v1.9.1", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/client-go@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/testify@v1.8.3",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
+  }, {
+    "ref" : "pkg:golang/go.opencensus.io@v0.22.4",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/protobuf@v1.5.2",
+    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/protobuf@v1.30.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.9",
+    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/net@v0.10.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/term@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/grpc@v1.31.0",
+    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/client9/misspell@v0.3.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sys@v0.8.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/text@v0.9.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+    "dependsOn" : [ "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/klog/v2@v2.80.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+    "dependsOn" : [ "pkg:golang/github.com/josharian/intern@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/josharian/intern@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f",
+    "dependsOn" : [ "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/google.golang.org/grpc@v1.31.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b" ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go@v0.65.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/mock@v1.4.4", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible", "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/github.com/google/martian/v3@v3.0.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/rsc.io/binaryregexp@v0.2.0" ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/cloud.google.com/go/datastore@v1.1.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+    "dependsOn" : [ "pkg:golang/google.golang.org/grpc@v1.31.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/tools@v0.6.0",
+    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.2.1", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/api@v0.30.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4", "pkg:golang/github.com/golang/protobuf@v1.5.2" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+    "dependsOn" : [ "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9", "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802", "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mod@v0.8.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+    "dependsOn" : [ "pkg:golang/github.com/burntsushi/toml@v0.3.1", "pkg:golang/github.com/google/renameio@v0.1.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/go.opencensus.io@v0.22.4", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/bigquery@v1.8.0", "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/cloud.google.com/go/storage@v1.10.0", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/appengine@v1.6.7",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+    "dependsOn" : [ "pkg:golang/github.com/bytedance/sonic@v1.9.1", "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.14.0", "pkg:golang/github.com/goccy/go-json@v0.10.2", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mattn/go-isatty@v0.0.19", "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/github.com/ugorji/go/codec@v1.2.11", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2", "pkg:golang/github.com/go-playground/locales@v0.14.1", "pkg:golang/github.com/go-playground/universal-translator@v0.18.1", "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4", "pkg:golang/github.com/leodido/go-urn@v1.2.4", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1", "pkg:golang/golang.org/x/arch@v0.3.0", "pkg:golang/golang.org/x/crypto@v0.9.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.5.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/gofuzz@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/uuid@v1.1.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/imdario/mergo@v0.3.6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.12",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pretty@v0.3.1",
+    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/text@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1", "pkg:golang/github.com/creack/pty@v1.1.9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+    "dependsOn" : [ "pkg:golang/gopkg.in/errgo.v2@v2.1.0", "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e" ]
+  }, {
+    "ref" : "pkg:golang/github.com/spf13/pflag@v1.0.5",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9", "pkg:golang/google.golang.org/appengine@v1.6.7" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/term@v0.8.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/protobuf@v1.30.0",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/api@v0.26.1",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/apimachinery@v0.26.1",
+    "dependsOn" : [ "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/kr/text@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/client-go@v0.26.1",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible", "pkg:golang/github.com/gogo/protobuf@v1.3.2", "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7", "pkg:golang/github.com/imdario/mergo@v0.3.6", "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b", "pkg:golang/golang.org/x/term@v0.8.0", "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/k8s.io/api@v0.26.1", "pkg:golang/k8s.io/apimachinery@v0.26.1", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/google/btree@v1.0.1", "pkg:golang/github.com/josharian/intern@v1.0.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/moby/spdystream@v0.2.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/pkg/errors@v0.9.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/gopkg.in/inf.v0@v0.9.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+    "dependsOn" : [ "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46", "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a", "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0", "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0", "pkg:golang/github.com/go-openapi/swag@v0.19.14", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/google/uuid@v1.1.2", "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2", "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822", "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0", "pkg:golang/github.com/onsi/gomega@v1.23.0", "pkg:golang/github.com/spf13/pflag@v1.0.5", "pkg:golang/github.com/stretchr/testify@v1.8.3", "pkg:golang/google.golang.org/protobuf@v1.30.0", "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/gopkg.in/yaml.v3@v3.0.1", "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c", "pkg:golang/k8s.io/klog/v2@v2.80.1", "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d", "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3", "pkg:golang/sigs.k8s.io/yaml@v1.3.0", "pkg:golang/github.com/puerkitobio/purell@v1.1.1", "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/mailru/easyjson@v0.7.6", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd", "pkg:golang/github.com/modern-go/reflect2@v1.0.2", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/golang.org/x/mod@v0.8.0", "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/golang.org/x/text@v0.9.0", "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/k8s.io/klog/v2@v2.80.1" ]
+  }, {
+    "ref" : "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+    "dependsOn" : [ "pkg:golang/gopkg.in/yaml.v2@v2.4.0", "pkg:golang/github.com/google/gofuzz@v1.1.0", "pkg:golang/github.com/json-iterator/go@v1.1.12", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd" ]
+  }, {
+    "ref" : "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/gopkg.in/yaml.v2@v2.4.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/crypto@v0.9.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/mock@v1.4.4",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.6.0", "pkg:golang/rsc.io/quote/v3@v3.1.0" ]
+  }, {
+    "ref" : "pkg:golang/rsc.io/quote/v3@v3.1.0",
+    "dependsOn" : [ "pkg:golang/rsc.io/sampler@v1.3.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.2.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mobile@v0.0.0-20190719004257-d2bd2a29d028",
+    "dependsOn" : [ "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/image@v0.0.0-20190802002840-cff245a6509b", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/moby/spdystream@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/gomega@v1.23.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pkg/errors@v0.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/martian/v3@v3.0.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.10.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/envoyproxy/go-control-plane@v0.9.4",
+    "dependsOn" : [ "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1", "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20191209042840-269d4d468f6f", "pkg:golang/github.com/google/go-cmp@v0.5.9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.2.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+    "dependsOn" : [ "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9" ]
+  }, {
+    "ref" : "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/goccy/go-json@v0.10.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/locales@v0.14.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/arch@v0.3.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/btree@v1.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/errgo.v2@v2.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/kr/pretty@v0.3.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f" ]
+  }, {
+    "ref" : "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/burntsushi/toml@v0.3.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/renameio@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+    "dependsOn" : [ "pkg:golang/github.com/chzyer/logex@v1.1.10", "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e", "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1", "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6", "pkg:golang/golang.org/x/sys@v0.8.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/chzyer/logex@v1.1.10",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20181102032728-5e5cf60278f6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/nytimes/gziphandler@v0.0.0-20170623195520-56545f4a5d46",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20190424111038-f61b66f89f4a",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/mitchellh/mapstructure@v1.1.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/k8s.io/gengo@v0.0.0-20210813121822-485abfe95c7c",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/puerkitobio/purell@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/puerkitobio/urlesc@v0.0.0-20170810143723-de5bf2ad4578",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+    "dependsOn" : [ "pkg:golang/cloud.google.com/go@v0.65.0", "pkg:golang/github.com/golang/protobuf@v1.5.2", "pkg:golang/github.com/google/go-cmp@v0.5.9", "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5", "pkg:golang/golang.org/x/sys@v0.8.0", "pkg:golang/google.golang.org/api@v0.30.0", "pkg:golang/google.golang.org/appengine@v1.6.7", "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154", "pkg:golang/google.golang.org/grpc@v1.31.0", "pkg:golang/cloud.google.com/go/pubsub@v1.3.1", "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6", "pkg:golang/golang.org/x/tools@v0.6.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/creack/pty@v1.1.9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/client9/misspell@v0.3.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/rsc.io/sampler@v1.3.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.9.0" ]
+  }, {
+    "ref" : "pkg:golang/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/burntsushi/xgb@v0.0.0-20160522181843-27f122750802",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20200222043503-6f7a984d4dc4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-gl/glfw@v0.0.0-20190409004039-e6da0acd62b1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/rsc.io/binaryregexp@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.8.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+    "dependsOn" : [ ]
+  } ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_with_one_ignored_prefix_go/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_with_one_ignored_prefix_go/expected_sbom_stack_analysis.json
@@ -1,1980 +1,3021 @@
 {
-  "bomFormat" : "CycloneDX",
-  "specVersion" : "1.4",
-  "version" : 1,
-  "metadata" : {
-    "component" : {
-      "type" : "application",
-      "bom-ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-      "group" : "github.com/devfile-samples",
-      "name" : "devfile-sample-go-basic",
-      "version" : "v0.0.0",
-      "purl" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+      "group": "github.com/devfile-samples",
+      "name": "devfile-sample-go-basic",
+      "version": "v0.0.0",
+      "purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
     }
   },
-  "components" : [ {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-verifcid",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-    "group" : "github.com/ipfs",
-    "name" : "go-cid",
-    "version" : "v0.0.7",
-    "purl" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-    "group" : "github.com/multiformats",
-    "name" : "go-multihash",
-    "version" : "v0.0.15",
-    "purl" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-conn-security-multistream",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-core",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-testing",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-    "group" : "github.com/multiformats",
-    "name" : "go-multistream",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-discovery",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-log",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-log@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-blankhost",
-    "version" : "v0.1.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-swarm",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-    "group" : "github.com/gogo",
-    "name" : "protobuf",
-    "version" : "v1.3.1",
-    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-    "group" : "github.com/mattn",
-    "name" : "go-colorable",
-    "version" : "v0.1.7",
-    "purl" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-    "group" : "github.com/opentracing",
-    "name" : "opentracing-go",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
-    "group" : "github.com/stretchr",
-    "name" : "testify",
-    "version" : "v1.7.0",
-    "purl" : "pkg:golang/github.com/stretchr/testify@v1.7.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-    "group" : "github.com/whyrusleeping",
-    "name" : "go-logging",
-    "version" : "v0.0.0-20170515211332-0457bb6b88fc",
-    "purl" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-    "group" : "golang.org/x",
-    "name" : "net",
-    "version" : "v0.0.0-20200822124328-c89045814202",
-    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
-    "group" : "github.com/huin",
-    "name" : "goupnp",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/huin/goupnp@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-    "group" : "github.com/huin",
-    "name" : "goutil",
-    "version" : "v0.0.0-20170803182201-1ca381bf3150",
-    "purl" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.3",
-    "group" : "golang.org/x",
-    "name" : "text",
-    "version" : "v0.3.3",
-    "purl" : "pkg:golang/golang.org/x/text@v0.3.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-yamux",
-    "version" : "v1.2.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-buffer-pool",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-    "group" : "github.com/ipld",
-    "name" : "go-codec-dagpb",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-    "group" : "github.com/ipld",
-    "name" : "go-ipld-prime",
-    "version" : "v0.9.0",
-    "purl" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-    "group" : "github.com/mr-tron",
-    "name" : "base58",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/mr-tron/base58@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-    "group" : "github.com/multiformats",
-    "name" : "go-varint",
-    "version" : "v0.0.6",
-    "purl" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-    "group" : "github.com/polydawn",
-    "name" : "refmt",
-    "version" : "v0.0.0-20201211092308-30ac6d18308e",
-    "purl" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "group" : "golang.org/x",
-    "name" : "xerrors",
-    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
-    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-blockservice",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-bitswap",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-    "group" : "github.com/ipfs",
-    "name" : "go-block-format",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-datastore",
-    "version" : "v0.3.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-blockstore",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-blocksutil",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-delay",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-exchange-interface",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-exchange-offline",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-routing",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-util",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "group" : "github.com/gin-contrib",
-    "name" : "sse",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ds-leveldb",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-    "group" : "github.com/jbenet",
-    "name" : "goprocess",
-    "version" : "v0.1.3",
-    "purl" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-    "group" : "github.com/syndtr",
-    "name" : "goleveldb",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-    "group" : "github.com/leodido",
-    "name" : "go-urn",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
-    "group" : "golang.org/x",
-    "name" : "mod",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/golang.org/x/mod@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-    "group" : "golang.org/x",
-    "name" : "crypto",
-    "version" : "v0.0.0-20210220033148-5ea612d1eb83",
-    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-    "group" : "golang.org/x",
-    "name" : "tools",
-    "version" : "v0.0.0-20200509030707-2212a7e161a5",
-    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-    "group" : "github.com/kisielk",
-    "name" : "errcheck",
-    "version" : "v1.2.0",
-    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "group" : "github.com/kisielk",
-    "name" : "gotool",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-detect-race",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-    "group" : "github.com/jbenet",
-    "name" : "go-cienv",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-autonat",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-circuit",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-loggables",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-mplex",
-    "version" : "v0.2.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-nat",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-netutil",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-peerstore",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-secio",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-transport-upgrader",
-    "version" : "v0.1.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-yamux",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-    "group" : "github.com/libp2p",
-    "name" : "go-maddr-filter",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-stream-muxer-multistream",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-tcp-transport",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-ws-transport",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/miekg/dns@v1.1.12",
-    "group" : "github.com/miekg",
-    "name" : "dns",
-    "version" : "v1.1.12",
-    "purl" : "pkg:golang/github.com/miekg/dns@v1.1.12"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr-dns",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr-net",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-    "group" : "github.com/whyrusleeping",
-    "name" : "mdns",
-    "version" : "v0.0.0-20180901202407-ef14215e6b30",
-    "purl" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
-    "group" : "github.com/google",
-    "name" : "go-cmp",
-    "version" : "v0.5.4",
-    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "group" : "github.com/hashicorp",
-    "name" : "golang-lru",
-    "version" : "v0.5.1",
-    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-    "group" : "github.com/ipfs",
-    "name" : "bbloom",
-    "version" : "v0.0.4",
-    "purl" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-ds-help",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-metrics-interface",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-    "group" : "github.com/btcsuite",
-    "name" : "btcd",
-    "version" : "v0.0.0-20190523000118-16327141da8c",
-    "purl" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-    "group" : "github.com/coreos",
-    "name" : "go-semver",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/github.com/coreos/go-semver@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-flow-metrics",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-    "group" : "github.com/minio",
-    "name" : "sha256-simd",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-    "group" : "github.com/spacemonkeygo",
-    "name" : "openssl",
-    "version" : "v0.0.0-20181017203307-c2dcc5cca94a",
-    "purl" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-    "group" : "github.com/multiformats",
-    "name" : "go-multibase",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-    "group" : "github.com/multiformats",
-    "name" : "go-base32",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
-    "group" : "github.com/multiformats",
-    "name" : "go-base36",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
-    "group" : "github.com/ugorji",
-    "name" : "go",
-    "version" : "v1.1.7",
-    "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-    "group" : "github.com/ugorji/go",
-    "name" : "codec",
-    "version" : "v1.1.7",
-    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-mplex",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-stream-muxer",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-    "group" : "howett.net",
-    "name" : "plist",
-    "version" : "v0.0.0-20181124034731-591f970eefbb",
-    "purl" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-    "group" : "github.com/jessevdk",
-    "name" : "go-flags",
-    "version" : "v1.4.0",
-    "purl" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
-    "group" : "github.com/kr",
-    "name" : "pretty",
-    "version" : "v0.2.1",
-    "purl" : "pkg:golang/github.com/kr/pretty@v0.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-    "group" : "gopkg.in",
-    "name" : "check.v1",
-    "version" : "v1.0.0-20180628173108-788fd7840127",
-    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-    "group" : "gopkg.in",
-    "name" : "yaml.v2",
-    "version" : "v2.2.8",
-    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-    "group" : "github.com/go-playground/validator",
-    "name" : "v10",
-    "version" : "v10.2.0",
-    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-    "group" : "github.com/go-playground/assert",
-    "name" : "v2",
-    "version" : "v2.0.1",
-    "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
-    "group" : "github.com/go-playground",
-    "name" : "locales",
-    "version" : "v0.13.0",
-    "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-    "group" : "github.com/go-playground",
-    "name" : "universal-translator",
-    "version" : "v0.17.0",
-    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-    "group" : "github.com/libp2p",
-    "name" : "go-nat",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-    "group" : "github.com/whyrusleeping",
-    "name" : "go-notifier",
-    "version" : "v0.0.0-20170827234753-097c5d47330f",
-    "purl" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipld/go-car@v0.3.0",
-    "group" : "github.com/ipld",
-    "name" : "go-car",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/github.com/ipld/go-car@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipld-cbor",
-    "version" : "v0.0.5",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipld-format",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-    "group" : "github.com/ipfs",
-    "name" : "go-merkledag",
-    "version" : "v0.3.2",
-    "purl" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-    "group" : "go.elastic.co",
-    "name" : "fastjson",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/go.elastic.co/fastjson@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
-    "group" : "github.com/pkg",
-    "name" : "errors",
-    "version" : "v0.8.1",
-    "purl" : "pkg:golang/github.com/pkg/errors@v0.8.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-    "group" : "github.com/valyala",
-    "name" : "fasttemplate",
-    "version" : "v1.2.1",
-    "purl" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-    "group" : "github.com/valyala",
-    "name" : "bytebufferpool",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
-    "group" : "github.com/labstack",
-    "name" : "gommon",
-    "version" : "v0.3.0",
-    "purl" : "pkg:golang/github.com/labstack/gommon@v0.3.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-    "group" : "github.com/mattn",
-    "name" : "go-isatty",
-    "version" : "v0.0.12",
-    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "group" : "github.com/davecgh",
-    "name" : "go-spew",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "group" : "github.com/pmezard",
-    "name" : "go-difflib",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "group" : "github.com/stretchr",
-    "name" : "objx",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-msgio",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
-    "group" : "github.com/google",
-    "name" : "uuid",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/google/uuid@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-    "group" : "golang.org/x",
-    "name" : "term",
-    "version" : "v0.0.0-20201117132131-f5c789dd3221",
-    "purl" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-    "group" : "golang.org/x",
-    "name" : "sys",
-    "version" : "v0.0.0-20210309074719-68d13333faf2",
-    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-addr-util",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-    "group" : "github.com/whyrusleeping",
-    "name" : "mafmt",
-    "version" : "v1.2.8",
-    "purl" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-    "group" : "github.com/whyrusleeping",
-    "name" : "multiaddr-filter",
-    "version" : "v0.0.0-20160516205228-e903e4adabd7",
-    "purl" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-    "group" : "github.com/prometheus",
-    "name" : "procfs",
-    "version" : "v0.0.3",
-    "purl" : "pkg:golang/github.com/prometheus/procfs@v0.0.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-    "group" : "golang.org/x",
-    "name" : "sync",
-    "version" : "v0.0.0-20190911185100-cd5d95a43a6e",
-    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-    "group" : "github.com/klauspost/cpuid",
-    "name" : "v2",
-    "version" : "v2.0.4",
-    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-    "group" : "github.com/gorilla",
-    "name" : "websocket",
-    "version" : "v1.4.0",
-    "purl" : "pkg:golang/github.com/gorilla/websocket@v1.4.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
-    "group" : "github.com/gin-gonic",
-    "name" : "gin",
-    "version" : "v1.6.0",
-    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.6.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
-    "group" : "github.com/labstack/echo",
-    "name" : "v4",
-    "version" : "v4.1.18-0.20201215153152-4422e3b66b9f",
-    "purl" : "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
-    "group" : "github.com/russellhaering",
-    "name" : "goxmldsig",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/go.elastic.co/apm@v1.11.0",
-    "group" : "go.elastic.co",
-    "name" : "apm",
-    "version" : "v1.11.0",
-    "purl" : "pkg:golang/go.elastic.co/apm@v1.11.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-    "group" : "github.com/elastic",
-    "name" : "go-sysinfo",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-    "group" : "github.com/elastic",
-    "name" : "go-windows",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/elastic/go-windows@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-    "group" : "github.com/joeshaw",
-    "name" : "multierror",
-    "version" : "v0.0.0-20140124173710-69b34d4ec901",
-    "purl" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
-    "group" : "github.com/gxed/hashland",
-    "name" : "keccakpg",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
-    "group" : "github.com/gxed/hashland",
-    "name" : "murmur3",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-    "group" : "github.com/minio",
-    "name" : "blake2b-simd",
-    "version" : "v0.0.0-20160723061019-3f5f724cb5b1",
-    "purl" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-    "group" : "github.com/spaolacci",
-    "name" : "murmur3",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
-    "group" : "github.com/golang",
-    "name" : "protobuf",
-    "version" : "v1.3.3",
-    "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-    "group" : "google.golang.org",
-    "name" : "genproto",
-    "version" : "v0.0.0-20180831171423-11092d34479b",
-    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-    "group" : "github.com/ipfs",
-    "name" : "go-ds-badger",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-crypto",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-peer",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-    "group" : "github.com/whyrusleeping",
-    "name" : "go-keyspace",
-    "version" : "v0.0.0-20160322163242-5b898ac5add1",
-    "purl" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-libp2p-record",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-    "group" : "github.com/andreasbriese",
-    "name" : "bbloom",
-    "version" : "v0.0.0-20180913140656-343706a395b7",
-    "purl" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-    "group" : "github.com/kubuxu",
-    "name" : "go-os-helper",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-    "group" : "github.com/dgraph-io",
-    "name" : "badger",
-    "version" : "v1.5.5-0.20190226225317-8115aed38f8f",
-    "purl" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-    "group" : "github.com/dgryski",
-    "name" : "go-farm",
-    "version" : "v0.0.0-20190104051053-3adb47b1fb0f",
-    "purl" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-    "group" : "github.com/dustin",
-    "name" : "go-humanize",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-    "group" : "github.com/spacemonkeygo",
-    "name" : "spacelog",
-    "version" : "v0.0.0-20180420211403-2296661a0572",
-    "purl" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-    "group" : "github.com/libp2p",
-    "name" : "go-reuseport",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-    "group" : "github.com/libp2p",
-    "name" : "go-reuseport-transport",
-    "version" : "v0.0.2",
-    "purl" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-    "group" : "github.com/multiformats",
-    "name" : "go-multiaddr-fmt",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-    "group" : "github.com/frankban",
-    "name" : "quicktest",
-    "version" : "v1.11.3",
-    "purl" : "pkg:golang/github.com/frankban/quicktest@v1.11.3"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-    "group" : "github.com/go-check",
-    "name" : "check",
-    "version" : "v0.0.0-20180628173108-788fd7840127",
-    "purl" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-    "group" : "github.com/smartystreets",
-    "name" : "goconvey",
-    "version" : "v1.6.4",
-    "purl" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-    "group" : "github.com/warpfork",
-    "name" : "go-wish",
-    "version" : "v0.0.0-20200122115046-b9ea61034e4a",
-    "purl" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-    "group" : "github.com/whyrusleeping",
-    "name" : "cbor-gen",
-    "version" : "v0.0.0-20200123233031-1cdf64d27158",
-    "purl" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/text@v0.1.0",
-    "group" : "github.com/kr",
-    "name" : "text",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/kr/text@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
-    "group" : "github.com/aead",
-    "name" : "siphash",
-    "version" : "v1.0.1",
-    "purl" : "pkg:golang/github.com/aead/siphash@v1.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-    "group" : "github.com/btcsuite",
-    "name" : "btclog",
-    "version" : "v0.0.0-20170628155309-84c8d2346e9f",
-    "purl" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-    "group" : "github.com/btcsuite",
-    "name" : "btcutil",
-    "version" : "v0.0.0-20190425235716-9e5f4b9a998d",
-    "purl" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-    "group" : "github.com/btcsuite",
-    "name" : "go-socks",
-    "version" : "v0.0.0-20170105172521-4720035b7bfd",
-    "purl" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-    "group" : "github.com/btcsuite",
-    "name" : "goleveldb",
-    "version" : "v0.0.0-20160330041536-7834afc9e8cd",
-    "purl" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-    "group" : "github.com/btcsuite",
-    "name" : "snappy-go",
-    "version" : "v0.0.0-20151229074030-0bdef8d06723",
-    "purl" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-    "group" : "github.com/btcsuite",
-    "name" : "websocket",
-    "version" : "v0.0.0-20150119174127-31079b680792",
-    "purl" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-    "group" : "github.com/btcsuite",
-    "name" : "winsvc",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-    "group" : "github.com/jrick",
-    "name" : "logrotate",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/jrick/logrotate@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-    "group" : "github.com/kkdai",
-    "name" : "bstream",
-    "version" : "v0.0.0-20161212061736-f391b8402d23",
-    "purl" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-    "group" : "github.com/onsi",
-    "name" : "ginkgo",
-    "version" : "v1.8.0",
-    "purl" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
-    "group" : "github.com/onsi",
-    "name" : "gomega",
-    "version" : "v1.5.0",
-    "purl" : "pkg:golang/github.com/onsi/gomega@v1.5.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "group" : "github.com/kr",
-    "name" : "pty",
-    "version" : "v1.1.1",
-    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-    "group" : "github.com/jbenet",
-    "name" : "go-temp-err-catcher",
-    "version" : "v0.0.0-20150120210811-aac704a3f4f2",
-    "purl" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
-    "group" : "github.com/armon",
-    "name" : "go-radix",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/armon/go-radix@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
-    "group" : "github.com/cucumber",
-    "name" : "godog",
-    "version" : "v0.8.1",
-    "purl" : "pkg:golang/github.com/cucumber/godog@v0.8.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-    "group" : "github.com/santhosh-tekuri",
-    "name" : "jsonschema",
-    "version" : "v1.2.4",
-    "purl" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
-    "group" : "github.com/yuin",
-    "name" : "goldmark",
-    "version" : "v1.1.27",
-    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.1.27"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
-    "group" : "github.com/beevik",
-    "name" : "etree",
-    "version" : "v1.1.0",
-    "purl" : "pkg:golang/github.com/beevik/etree@v1.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-    "group" : "github.com/jonboulle",
-    "name" : "clockwork",
-    "version" : "v0.2.0",
-    "purl" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-    "group" : "github.com/fsnotify",
-    "name" : "fsnotify",
-    "version" : "v1.4.7",
-    "purl" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-    "group" : "github.com/hpcloud",
-    "name" : "tail",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/hpcloud/tail@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-    "group" : "gopkg.in",
-    "name" : "fsnotify.v1",
-    "version" : "v1.4.7",
-    "purl" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-    "group" : "gopkg.in",
-    "name" : "tomb.v1",
-    "version" : "v1.0.0-20141024135613-dd632973f1e7",
-    "purl" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
-    "group" : "github.com/json-iterator",
-    "name" : "go",
-    "version" : "v1.1.9",
-    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
-    "group" : "github.com/google",
-    "name" : "gofuzz",
-    "version" : "v1.0.0",
-    "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-    "group" : "github.com/modern-go",
-    "name" : "concurrent",
-    "version" : "v0.0.0-20180228061459-e0a39a4cb421",
-    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-    "group" : "github.com/modern-go",
-    "name" : "reflect2",
-    "version" : "v0.0.0-20180701023420-4b7aa43c6742",
-    "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-    "group" : "github.com/gopherjs",
-    "name" : "gopherjs",
-    "version" : "v0.0.0-20181017120253-0766667cb4d1",
-    "purl" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-    "group" : "github.com/jtolds",
-    "name" : "gls",
-    "version" : "v4.20.0+incompatible",
-    "purl" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-    "group" : "github.com/smartystreets",
-    "name" : "assertions",
-    "version" : "v0.0.0-20180927180507-b2de0cb4f26d",
-    "purl" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-    "group" : "github.com/golang",
-    "name" : "snappy",
-    "version" : "v0.0.0-20180518054509-2e65f85255db",
-    "purl" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-    "group" : "github.com/cskr",
-    "name" : "pubsub",
-    "version" : "v1.0.2",
-    "purl" : "pkg:golang/github.com/cskr/pubsub@v1.0.2"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-    "group" : "github.com/ipfs",
-    "name" : "go-peertaskqueue",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-    "group" : "github.com/libp2p",
-    "name" : "go-testutil",
-    "version" : "v0.1.0",
-    "purl" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-    "group" : "github.com/jackpal",
-    "name" : "gateway",
-    "version" : "v1.0.5",
-    "purl" : "pkg:golang/github.com/jackpal/gateway@v1.0.5"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-    "group" : "github.com/jackpal",
-    "name" : "go-nat-pmp",
-    "version" : "v1.0.1",
-    "purl" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-    "group" : "github.com/koron",
-    "name" : "go-ssdp",
-    "version" : "v0.0.0-20180514024734-4a0ed625a78b",
-    "purl" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-    "group" : "github.com/dgrijalva",
-    "name" : "jwt-go",
-    "version" : "v3.2.0+incompatible",
-    "purl" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
-  }, {
-    "type" : "library",
-    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-    "group" : "github.com/ipfs",
-    "name" : "go-ipfs-pq",
-    "version" : "v0.0.1",
-    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
-  } ],
-  "dependencies" : [ {
-    "ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/gin-gonic/gin@v1.6.0", "pkg:golang/github.com/ipld/go-car@v0.3.0", "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f", "pkg:golang/github.com/miekg/dns@v1.1.12", "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0", "pkg:golang/go.elastic.co/apm@v1.11.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multibase@v0.0.3", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-    "dependsOn" : [ "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1", "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1", "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/github.com/spaolacci/murmur3@v1.1.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c", "pkg:golang/github.com/coreos/go-semver@v0.3.0", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8", "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.2.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/text@v0.3.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-    "dependsOn" : [ "pkg:golang/github.com/frankban/quicktest@v1.11.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/cskr/pubsub@v1.0.2", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-testutil@v0.1.0", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-    "dependsOn" : [ "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/bbloom@v0.0.4", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/syndtr/goleveldb@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-    "dependsOn" : [ "pkg:golang/github.com/jbenet/go-cienv@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.1.27", "pkg:golang/golang.org/x/mod@v0.2.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0", "pkg:golang/github.com/miekg/dns@v1.1.12", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0", "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-mplex@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-nat@v0.0.3", "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2", "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-msgio@v0.0.2", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-yamux@v1.2.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gorilla/websocket@v1.4.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/miekg/dns@v1.1.12",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
-    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/multiformats/go-base32@v0.0.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-    "dependsOn" : [ "pkg:golang/github.com/aead/siphash@v1.0.1", "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f", "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d", "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd", "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd", "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723", "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792", "pkg:golang/github.com/btcsuite/winsvc@v1.0.0", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/jrick/logrotate@v1.0.0", "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
-  }, {
-    "ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4" ]
-  }, {
-    "ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-    "dependsOn" : [ "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-base36@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/ugorji/go/codec@v1.1.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-    "dependsOn" : [ "pkg:golang/github.com/ugorji/go@v1.1.7" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-    "dependsOn" : [ "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
-    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.1.0" ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-playground/assert/v2@v2.0.1", "pkg:golang/github.com/go-playground/locales@v0.13.0", "pkg:golang/github.com/go-playground/universal-translator@v0.17.0", "pkg:golang/github.com/leodido/go-urn@v1.2.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
-    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-    "dependsOn" : [ "pkg:golang/github.com/go-playground/locales@v0.13.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-    "dependsOn" : [ "pkg:golang/github.com/huin/goupnp@v1.0.0", "pkg:golang/github.com/jackpal/gateway@v1.0.5", "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1", "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipld/go-car@v0.3.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2", "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0", "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a", "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-    "dependsOn" : [ "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
-    "dependsOn" : [ "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/valyala/fasttemplate@v1.2.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/github.com/google/go-cmp@v0.5.4" ]
-  }, {
-    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
-    "dependsOn" : [ "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.2.0", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/json-iterator/go@v1.1.9", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/ugorji/go/codec@v1.1.7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
-    "dependsOn" : [ "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible", "pkg:golang/github.com/labstack/gommon@v0.3.0", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/valyala/fasttemplate@v1.2.1", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3" ]
-  }, {
-    "ref" : "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/beevik/etree@v1.1.0", "pkg:golang/github.com/jonboulle/clockwork@v0.2.0", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/go.elastic.co/apm@v1.11.0",
-    "dependsOn" : [ "pkg:golang/github.com/armon/go-radix@v1.0.0", "pkg:golang/github.com/cucumber/godog@v0.8.1", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1", "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/prometheus/procfs@v0.0.3", "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/go.elastic.co/fastjson@v1.1.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-    "dependsOn" : [ "pkg:golang/github.com/elastic/go-windows@v1.0.0", "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/prometheus/procfs@v0.0.3", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb" ]
-  }, {
-    "ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
-    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b" ]
-  }, {
-    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7", "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1", "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f", "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f", "pkg:golang/github.com/dustin/go-humanize@v1.0.0", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/pkg/errors@v0.8.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/kr/pretty@v0.2.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-    "dependsOn" : [ "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1", "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible", "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
-  }, {
-    "ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/text@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1" ]
-  }, {
-    "ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
-    "dependsOn" : [ "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/hpcloud/tail@v1.0.0", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7", "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
-  }, {
-    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
-    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.0.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421", "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
-  }, {
-    "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
-  }, {
-    "ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
-  }, {
-    "ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-    "dependsOn" : [ ]
-  }, {
-    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-    "dependsOn" : [ ]
-  } ]
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-verifcid",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+      "group": "github.com/ipfs",
+      "name": "go-cid",
+      "version": "v0.0.7",
+      "purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+      "group": "github.com/multiformats",
+      "name": "go-multihash",
+      "version": "v0.0.15",
+      "purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-conn-security-multistream",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-core",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-testing",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+      "group": "github.com/multiformats",
+      "name": "go-multistream",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-discovery",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-log",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-log@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-blankhost",
+      "version": "v0.1.1",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-swarm",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+      "group": "github.com/gogo",
+      "name": "protobuf",
+      "version": "v1.3.1",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+      "group": "github.com/mattn",
+      "name": "go-colorable",
+      "version": "v0.1.7",
+      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+      "group": "github.com/opentracing",
+      "name": "opentracing-go",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+      "group": "github.com/stretchr",
+      "name": "testify",
+      "version": "v1.7.0",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.7.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+      "group": "github.com/whyrusleeping",
+      "name": "go-logging",
+      "version": "v0.0.0-20170515211332-0457bb6b88fc",
+      "purl": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+      "group": "golang.org/x",
+      "name": "net",
+      "version": "v0.0.0-20200822124328-c89045814202",
+      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
+      "group": "github.com/huin",
+      "name": "goupnp",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/huin/goupnp@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+      "group": "github.com/huin",
+      "name": "goutil",
+      "version": "v0.0.0-20170803182201-1ca381bf3150",
+      "purl": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.3",
+      "group": "golang.org/x",
+      "name": "text",
+      "version": "v0.3.3",
+      "purl": "pkg:golang/golang.org/x/text@v0.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+      "group": "github.com/libp2p",
+      "name": "go-yamux",
+      "version": "v1.2.2",
+      "purl": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-buffer-pool",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+      "group": "github.com/ipld",
+      "name": "go-codec-dagpb",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+      "group": "github.com/ipld",
+      "name": "go-ipld-prime",
+      "version": "v0.9.0",
+      "purl": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+      "group": "github.com/mr-tron",
+      "name": "base58",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/mr-tron/base58@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+      "group": "github.com/multiformats",
+      "name": "go-varint",
+      "version": "v0.0.6",
+      "purl": "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+      "group": "github.com/polydawn",
+      "name": "refmt",
+      "version": "v0.0.0-20201211092308-30ac6d18308e",
+      "purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "group": "golang.org/x",
+      "name": "xerrors",
+      "version": "v0.0.0-20200804184101-5ec99f83aff1",
+      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-blockservice",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-bitswap",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+      "group": "github.com/ipfs",
+      "name": "go-block-format",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+      "group": "github.com/ipfs",
+      "name": "go-datastore",
+      "version": "v0.3.1",
+      "purl": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-blockstore",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-blocksutil",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-delay",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-exchange-interface",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-exchange-offline",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-routing",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-util",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "group": "github.com/gin-contrib",
+      "name": "sse",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ds-leveldb",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+      "group": "github.com/jbenet",
+      "name": "goprocess",
+      "version": "v0.1.3",
+      "purl": "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+      "group": "github.com/syndtr",
+      "name": "goleveldb",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "group": "github.com/leodido",
+      "name": "go-urn",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.2.0",
+      "group": "golang.org/x",
+      "name": "mod",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/golang.org/x/mod@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+      "group": "golang.org/x",
+      "name": "crypto",
+      "version": "v0.0.0-20210220033148-5ea612d1eb83",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+      "group": "golang.org/x",
+      "name": "tools",
+      "version": "v0.0.0-20200509030707-2212a7e161a5",
+      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+      "group": "github.com/kisielk",
+      "name": "errcheck",
+      "version": "v1.2.0",
+      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "group": "github.com/kisielk",
+      "name": "gotool",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-detect-race",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+      "group": "github.com/jbenet",
+      "name": "go-cienv",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-autonat",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-circuit",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-loggables",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-mplex",
+      "version": "v0.2.1",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-nat",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-netutil",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-peerstore",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-secio",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-transport-upgrader",
+      "version": "v0.1.1",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-yamux",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+      "group": "github.com/libp2p",
+      "name": "go-maddr-filter",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+      "group": "github.com/libp2p",
+      "name": "go-stream-muxer-multistream",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-tcp-transport",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-ws-transport",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/miekg/dns@v1.1.12",
+      "group": "github.com/miekg",
+      "name": "dns",
+      "version": "v1.1.12",
+      "purl": "pkg:golang/github.com/miekg/dns@v1.1.12"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr-dns",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr-net",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+      "group": "github.com/whyrusleeping",
+      "name": "mdns",
+      "version": "v0.0.0-20180901202407-ef14215e6b30",
+      "purl": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
+      "group": "github.com/google",
+      "name": "go-cmp",
+      "version": "v0.5.4",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "group": "github.com/hashicorp",
+      "name": "golang-lru",
+      "version": "v0.5.1",
+      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+      "group": "github.com/ipfs",
+      "name": "bbloom",
+      "version": "v0.0.4",
+      "purl": "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-ds-help",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-metrics-interface",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+      "group": "github.com/btcsuite",
+      "name": "btcd",
+      "version": "v0.0.0-20190523000118-16327141da8c",
+      "purl": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+      "group": "github.com/coreos",
+      "name": "go-semver",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-flow-metrics",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+      "group": "github.com/minio",
+      "name": "sha256-simd",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+      "group": "github.com/spacemonkeygo",
+      "name": "openssl",
+      "version": "v0.0.0-20181017203307-c2dcc5cca94a",
+      "purl": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+      "group": "github.com/multiformats",
+      "name": "go-multibase",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+      "group": "github.com/multiformats",
+      "name": "go-base32",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+      "group": "github.com/multiformats",
+      "name": "go-base36",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "group": "github.com/ugorji",
+      "name": "go",
+      "version": "v1.1.7",
+      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "group": "github.com/ugorji/go",
+      "name": "codec",
+      "version": "v1.1.7",
+      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-mplex",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-stream-muxer",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+      "group": "howett.net",
+      "name": "plist",
+      "version": "v0.0.0-20181124034731-591f970eefbb",
+      "purl": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+      "group": "github.com/jessevdk",
+      "name": "go-flags",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
+      "group": "github.com/kr",
+      "name": "pretty",
+      "version": "v0.2.1",
+      "purl": "pkg:golang/github.com/kr/pretty@v0.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+      "group": "gopkg.in",
+      "name": "check.v1",
+      "version": "v1.0.0-20180628173108-788fd7840127",
+      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "group": "gopkg.in",
+      "name": "yaml.v2",
+      "version": "v2.2.8",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+      "group": "github.com/go-playground/validator",
+      "name": "v10",
+      "version": "v10.2.0",
+      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "group": "github.com/go-playground/assert",
+      "name": "v2",
+      "version": "v2.0.1",
+      "purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "group": "github.com/go-playground",
+      "name": "locales",
+      "version": "v0.13.0",
+      "purl": "pkg:golang/github.com/go-playground/locales@v0.13.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "group": "github.com/go-playground",
+      "name": "universal-translator",
+      "version": "v0.17.0",
+      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+      "group": "github.com/libp2p",
+      "name": "go-nat",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+      "group": "github.com/whyrusleeping",
+      "name": "go-notifier",
+      "version": "v0.0.0-20170827234753-097c5d47330f",
+      "purl": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipld/go-car@v0.3.0",
+      "group": "github.com/ipld",
+      "name": "go-car",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/github.com/ipld/go-car@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+      "group": "github.com/ipfs",
+      "name": "go-ipld-cbor",
+      "version": "v0.0.5",
+      "purl": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+      "group": "github.com/ipfs",
+      "name": "go-ipld-format",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+      "group": "github.com/ipfs",
+      "name": "go-merkledag",
+      "version": "v0.3.2",
+      "purl": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+      "group": "go.elastic.co",
+      "name": "fastjson",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/go.elastic.co/fastjson@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
+      "group": "github.com/pkg",
+      "name": "errors",
+      "version": "v0.8.1",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.8.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+      "group": "github.com/valyala",
+      "name": "fasttemplate",
+      "version": "v1.2.1",
+      "purl": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+      "group": "github.com/valyala",
+      "name": "bytebufferpool",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "group": "github.com/labstack",
+      "name": "gommon",
+      "version": "v0.3.0",
+      "purl": "pkg:golang/github.com/labstack/gommon@v0.3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "group": "github.com/mattn",
+      "name": "go-isatty",
+      "version": "v0.0.12",
+      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "group": "github.com/davecgh",
+      "name": "go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "group": "github.com/pmezard",
+      "name": "go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "group": "github.com/stretchr",
+      "name": "objx",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-msgio",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.1",
+      "group": "github.com/google",
+      "name": "uuid",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/google/uuid@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+      "group": "golang.org/x",
+      "name": "term",
+      "version": "v0.0.0-20201117132131-f5c789dd3221",
+      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+      "group": "golang.org/x",
+      "name": "sys",
+      "version": "v0.0.0-20210309074719-68d13333faf2",
+      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-addr-util",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+      "group": "github.com/whyrusleeping",
+      "name": "mafmt",
+      "version": "v1.2.8",
+      "purl": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+      "group": "github.com/whyrusleeping",
+      "name": "multiaddr-filter",
+      "version": "v0.0.0-20160516205228-e903e4adabd7",
+      "purl": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+      "group": "github.com/prometheus",
+      "name": "procfs",
+      "version": "v0.0.3",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+      "group": "golang.org/x",
+      "name": "sync",
+      "version": "v0.0.0-20190911185100-cd5d95a43a6e",
+      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+      "group": "github.com/klauspost/cpuid",
+      "name": "v2",
+      "version": "v2.0.4",
+      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+      "group": "github.com/gorilla",
+      "name": "websocket",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/github.com/gorilla/websocket@v1.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
+      "group": "github.com/gin-gonic",
+      "name": "gin",
+      "version": "v1.6.0",
+      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
+      "group": "github.com/labstack/echo",
+      "name": "v4",
+      "version": "v4.1.18-0.20201215153152-4422e3b66b9f",
+      "purl": "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
+      "group": "github.com/russellhaering",
+      "name": "goxmldsig",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/go.elastic.co/apm@v1.11.0",
+      "group": "go.elastic.co",
+      "name": "apm",
+      "version": "v1.11.0",
+      "purl": "pkg:golang/go.elastic.co/apm@v1.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+      "group": "github.com/elastic",
+      "name": "go-sysinfo",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+      "group": "github.com/elastic",
+      "name": "go-windows",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/elastic/go-windows@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+      "group": "github.com/joeshaw",
+      "name": "multierror",
+      "version": "v0.0.0-20140124173710-69b34d4ec901",
+      "purl": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+      "group": "github.com/gxed/hashland",
+      "name": "keccakpg",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+      "group": "github.com/gxed/hashland",
+      "name": "murmur3",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+      "group": "github.com/minio",
+      "name": "blake2b-simd",
+      "version": "v0.0.0-20160723061019-3f5f724cb5b1",
+      "purl": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+      "group": "github.com/spaolacci",
+      "name": "murmur3",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "group": "github.com/golang",
+      "name": "protobuf",
+      "version": "v1.3.3",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+      "group": "google.golang.org",
+      "name": "genproto",
+      "version": "v0.0.0-20180831171423-11092d34479b",
+      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+      "group": "github.com/ipfs",
+      "name": "go-ds-badger",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-crypto",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-peer",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+      "group": "github.com/whyrusleeping",
+      "name": "go-keyspace",
+      "version": "v0.0.0-20160322163242-5b898ac5add1",
+      "purl": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-libp2p-record",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+      "group": "github.com/andreasbriese",
+      "name": "bbloom",
+      "version": "v0.0.0-20180913140656-343706a395b7",
+      "purl": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+      "group": "github.com/kubuxu",
+      "name": "go-os-helper",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+      "group": "github.com/dgraph-io",
+      "name": "badger",
+      "version": "v1.5.5-0.20190226225317-8115aed38f8f",
+      "purl": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+      "group": "github.com/dgryski",
+      "name": "go-farm",
+      "version": "v0.0.0-20190104051053-3adb47b1fb0f",
+      "purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+      "group": "github.com/dustin",
+      "name": "go-humanize",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+      "group": "github.com/spacemonkeygo",
+      "name": "spacelog",
+      "version": "v0.0.0-20180420211403-2296661a0572",
+      "purl": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+      "group": "github.com/libp2p",
+      "name": "go-reuseport",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+      "group": "github.com/libp2p",
+      "name": "go-reuseport-transport",
+      "version": "v0.0.2",
+      "purl": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+      "group": "github.com/multiformats",
+      "name": "go-multiaddr-fmt",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+      "group": "github.com/frankban",
+      "name": "quicktest",
+      "version": "v1.11.3",
+      "purl": "pkg:golang/github.com/frankban/quicktest@v1.11.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+      "group": "github.com/go-check",
+      "name": "check",
+      "version": "v0.0.0-20180628173108-788fd7840127",
+      "purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "group": "github.com/smartystreets",
+      "name": "goconvey",
+      "version": "v1.6.4",
+      "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+      "group": "github.com/warpfork",
+      "name": "go-wish",
+      "version": "v0.0.0-20200122115046-b9ea61034e4a",
+      "purl": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+      "group": "github.com/whyrusleeping",
+      "name": "cbor-gen",
+      "version": "v0.0.0-20200123233031-1cdf64d27158",
+      "purl": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/text@v0.1.0",
+      "group": "github.com/kr",
+      "name": "text",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/kr/text@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
+      "group": "github.com/aead",
+      "name": "siphash",
+      "version": "v1.0.1",
+      "purl": "pkg:golang/github.com/aead/siphash@v1.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+      "group": "github.com/btcsuite",
+      "name": "btclog",
+      "version": "v0.0.0-20170628155309-84c8d2346e9f",
+      "purl": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+      "group": "github.com/btcsuite",
+      "name": "btcutil",
+      "version": "v0.0.0-20190425235716-9e5f4b9a998d",
+      "purl": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+      "group": "github.com/btcsuite",
+      "name": "go-socks",
+      "version": "v0.0.0-20170105172521-4720035b7bfd",
+      "purl": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+      "group": "github.com/btcsuite",
+      "name": "goleveldb",
+      "version": "v0.0.0-20160330041536-7834afc9e8cd",
+      "purl": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+      "group": "github.com/btcsuite",
+      "name": "snappy-go",
+      "version": "v0.0.0-20151229074030-0bdef8d06723",
+      "purl": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+      "group": "github.com/btcsuite",
+      "name": "websocket",
+      "version": "v0.0.0-20150119174127-31079b680792",
+      "purl": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+      "group": "github.com/btcsuite",
+      "name": "winsvc",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+      "group": "github.com/jrick",
+      "name": "logrotate",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/jrick/logrotate@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+      "group": "github.com/kkdai",
+      "name": "bstream",
+      "version": "v0.0.0-20161212061736-f391b8402d23",
+      "purl": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+      "group": "github.com/onsi",
+      "name": "ginkgo",
+      "version": "v1.8.0",
+      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
+      "group": "github.com/onsi",
+      "name": "gomega",
+      "version": "v1.5.0",
+      "purl": "pkg:golang/github.com/onsi/gomega@v1.5.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "group": "github.com/kr",
+      "name": "pty",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/kr/pty@v1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+      "group": "github.com/jbenet",
+      "name": "go-temp-err-catcher",
+      "version": "v0.0.0-20150120210811-aac704a3f4f2",
+      "purl": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
+      "group": "github.com/armon",
+      "name": "go-radix",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/armon/go-radix@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+      "group": "github.com/cucumber",
+      "name": "godog",
+      "version": "v0.8.1",
+      "purl": "pkg:golang/github.com/cucumber/godog@v0.8.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+      "group": "github.com/santhosh-tekuri",
+      "name": "jsonschema",
+      "version": "v1.2.4",
+      "purl": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+      "group": "github.com/yuin",
+      "name": "goldmark",
+      "version": "v1.1.27",
+      "purl": "pkg:golang/github.com/yuin/goldmark@v1.1.27"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
+      "group": "github.com/beevik",
+      "name": "etree",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/beevik/etree@v1.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+      "group": "github.com/jonboulle",
+      "name": "clockwork",
+      "version": "v0.2.0",
+      "purl": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "group": "github.com/fsnotify",
+      "name": "fsnotify",
+      "version": "v1.4.7",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+      "group": "github.com/hpcloud",
+      "name": "tail",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+      "group": "gopkg.in",
+      "name": "fsnotify.v1",
+      "version": "v1.4.7",
+      "purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "group": "gopkg.in",
+      "name": "tomb.v1",
+      "version": "v1.0.0-20141024135613-dd632973f1e7",
+      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "group": "github.com/json-iterator",
+      "name": "go",
+      "version": "v1.1.9",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "group": "github.com/google",
+      "name": "gofuzz",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "group": "github.com/modern-go",
+      "name": "concurrent",
+      "version": "v0.0.0-20180228061459-e0a39a4cb421",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "group": "github.com/modern-go",
+      "name": "reflect2",
+      "version": "v0.0.0-20180701023420-4b7aa43c6742",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+      "group": "github.com/gopherjs",
+      "name": "gopherjs",
+      "version": "v0.0.0-20181017120253-0766667cb4d1",
+      "purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+      "group": "github.com/jtolds",
+      "name": "gls",
+      "version": "v4.20.0+incompatible",
+      "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+      "group": "github.com/smartystreets",
+      "name": "assertions",
+      "version": "v0.0.0-20180927180507-b2de0cb4f26d",
+      "purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+      "group": "github.com/golang",
+      "name": "snappy",
+      "version": "v0.0.0-20180518054509-2e65f85255db",
+      "purl": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+      "group": "github.com/cskr",
+      "name": "pubsub",
+      "version": "v1.0.2",
+      "purl": "pkg:golang/github.com/cskr/pubsub@v1.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+      "group": "github.com/ipfs",
+      "name": "go-peertaskqueue",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+      "group": "github.com/libp2p",
+      "name": "go-testutil",
+      "version": "v0.1.0",
+      "purl": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+      "group": "github.com/jackpal",
+      "name": "gateway",
+      "version": "v1.0.5",
+      "purl": "pkg:golang/github.com/jackpal/gateway@v1.0.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+      "group": "github.com/jackpal",
+      "name": "go-nat-pmp",
+      "version": "v1.0.1",
+      "purl": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+      "group": "github.com/koron",
+      "name": "go-ssdp",
+      "version": "v0.0.0-20180514024734-4a0ed625a78b",
+      "purl": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+      "group": "github.com/dgrijalva",
+      "name": "jwt-go",
+      "version": "v3.2.0+incompatible",
+      "purl": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+      "group": "github.com/ipfs",
+      "name": "go-ipfs-pq",
+      "version": "v0.0.1",
+      "purl": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
+        "pkg:golang/github.com/ipld/go-car@v0.3.0",
+        "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
+        "pkg:golang/github.com/miekg/dns@v1.1.12",
+        "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
+        "pkg:golang/go.elastic.co/apm@v1.11.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+      "dependsOn": [
+        "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+        "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+        "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+        "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+        "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+        "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+      "dependsOn": [
+        "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "pkg:golang/github.com/stretchr/objx@v0.1.0",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.3.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+      "dependsOn": [
+        "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+      "dependsOn": [
+        "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/kr/pretty@v0.2.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+      "dependsOn": [
+        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/github.com/onsi/gomega@v1.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/mod@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+      "dependsOn": [
+        "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+        "pkg:golang/golang.org/x/mod@v0.2.0",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+        "pkg:golang/github.com/miekg/dns@v1.1.12",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+        "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/google/uuid@v1.1.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+        "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+        "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/github.com/onsi/gomega@v1.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/miekg/dns@v1.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+      "dependsOn": [
+        "pkg:golang/github.com/aead/siphash@v1.0.1",
+        "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+        "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+        "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+        "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+        "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+        "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+        "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+        "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+        "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/github.com/onsi/gomega@v1.5.0",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+      "dependsOn": [
+        "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+        "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+      "dependsOn": [
+        "pkg:golang/github.com/ugorji/go@v1.1.7"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+      "dependsOn": [
+        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+        "pkg:golang/github.com/kr/pretty@v0.2.1",
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/text@v0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+      "dependsOn": [
+        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+        "pkg:golang/github.com/go-playground/locales@v0.13.0",
+        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+        "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+      "dependsOn": [
+        "pkg:golang/github.com/go-playground/locales@v0.13.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/github.com/huin/goupnp@v1.0.0",
+        "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+        "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+        "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipld/go-car@v0.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+        "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+        "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+        "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+        "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+        "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+      "dependsOn": [
+        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+      "dependsOn": [
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/uuid@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/github.com/google/go-cmp@v0.5.4"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+        "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/json-iterator/go@v1.1.9",
+        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
+      "dependsOn": [
+        "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+        "pkg:golang/github.com/labstack/gommon@v0.3.0",
+        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/beevik/etree@v1.1.0",
+        "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/go.elastic.co/apm@v1.11.0",
+      "dependsOn": [
+        "pkg:golang/github.com/armon/go-radix@v1.0.0",
+        "pkg:golang/github.com/cucumber/godog@v0.8.1",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+        "pkg:golang/github.com/google/go-cmp@v0.5.4",
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+        "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+      "dependsOn": [
+        "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+        "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+      "dependsOn": [
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+      ]
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+        "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+        "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+        "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+        "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+        "pkg:golang/github.com/pkg/errors@v0.8.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/pkg/errors@v0.8.1",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+      "dependsOn": [
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+      "dependsOn": [
+        "pkg:golang/github.com/google/go-cmp@v0.5.4",
+        "pkg:golang/github.com/kr/pretty@v0.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+      "dependsOn": [
+        "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+        "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+        "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+      "dependsOn": [
+        "pkg:golang/github.com/google/go-cmp@v0.5.4",
+        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/text@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/kr/pty@v1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
+      "dependsOn": [
+        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+        "pkg:golang/github.com/golang/protobuf@v1.3.3",
+        "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+        "pkg:golang/golang.org/x/text@v0.3.3",
+        "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+      "dependsOn": [
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "pkg:golang/github.com/google/gofuzz@v1.0.0",
+        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+        "pkg:golang/github.com/stretchr/testify@v1.7.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+      "dependsOn": [
+        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+      "dependsOn": []
+    }
+  ]
 }

--- a/src/test/resources/tst_manifests/golang/go_mod_with_one_ignored_prefix_go/expected_sbom_stack_analysis.json
+++ b/src/test/resources/tst_manifests/golang/go_mod_with_one_ignored_prefix_go/expected_sbom_stack_analysis.json
@@ -1,2947 +1,1980 @@
 {
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
-  "version": 1,
-  "metadata": {
-    "component": {
-      "type": "application",
-      "bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-      "group": "github.com/devfile-samples",
-      "name": "devfile-sample-go-basic",
-      "version": "v0.0.0",
-      "purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.4",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+      "group" : "github.com/devfile-samples",
+      "name" : "devfile-sample-go-basic",
+      "version" : "v0.0.0",
+      "purl" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
     }
   },
-  "components": [
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-verifcid",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-      "group": "github.com/ipfs",
-      "name": "go-cid",
-      "version": "v0.0.7",
-      "purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-      "group": "github.com/multiformats",
-      "name": "go-multihash",
-      "version": "v0.0.15",
-      "purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-conn-security-multistream",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-core",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-testing",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-      "group": "github.com/multiformats",
-      "name": "go-multistream",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-discovery",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-log",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-log@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-blankhost",
-      "version": "v0.1.1",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-swarm",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-      "group": "github.com/gogo",
-      "name": "protobuf",
-      "version": "v1.3.1",
-      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-      "group": "github.com/mattn",
-      "name": "go-colorable",
-      "version": "v0.1.7",
-      "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-      "group": "github.com/opentracing",
-      "name": "opentracing-go",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
-      "group": "github.com/stretchr",
-      "name": "testify",
-      "version": "v1.7.0",
-      "purl": "pkg:golang/github.com/stretchr/testify@v1.7.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-      "group": "github.com/whyrusleeping",
-      "name": "go-logging",
-      "version": "v0.0.0-20170515211332-0457bb6b88fc",
-      "purl": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-      "group": "golang.org/x",
-      "name": "net",
-      "version": "v0.0.0-20200822124328-c89045814202",
-      "purl": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
-      "group": "github.com/huin",
-      "name": "goupnp",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/huin/goupnp@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-      "group": "github.com/huin",
-      "name": "goutil",
-      "version": "v0.0.0-20170803182201-1ca381bf3150",
-      "purl": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/text@v0.3.3",
-      "group": "golang.org/x",
-      "name": "text",
-      "version": "v0.3.3",
-      "purl": "pkg:golang/golang.org/x/text@v0.3.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-      "group": "github.com/libp2p",
-      "name": "go-yamux",
-      "version": "v1.2.2",
-      "purl": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-buffer-pool",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-      "group": "github.com/ipld",
-      "name": "go-codec-dagpb",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-      "group": "github.com/ipld",
-      "name": "go-ipld-prime",
-      "version": "v0.9.0",
-      "purl": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-      "group": "github.com/mr-tron",
-      "name": "base58",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/mr-tron/base58@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-      "group": "github.com/multiformats",
-      "name": "go-varint",
-      "version": "v0.0.6",
-      "purl": "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-      "group": "github.com/polydawn",
-      "name": "refmt",
-      "version": "v0.0.0-20201211092308-30ac6d18308e",
-      "purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "group": "golang.org/x",
-      "name": "xerrors",
-      "version": "v0.0.0-20200804184101-5ec99f83aff1",
-      "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-blockservice",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-bitswap",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-      "group": "github.com/ipfs",
-      "name": "go-block-format",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-      "group": "github.com/ipfs",
-      "name": "go-datastore",
-      "version": "v0.3.1",
-      "purl": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-blockstore",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-blocksutil",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-delay",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-exchange-interface",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-exchange-offline",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-routing",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-util",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "group": "github.com/gin-contrib",
-      "name": "sse",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ds-leveldb",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-      "group": "github.com/jbenet",
-      "name": "goprocess",
-      "version": "v0.1.3",
-      "purl": "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-      "group": "github.com/syndtr",
-      "name": "goleveldb",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-      "group": "github.com/leodido",
-      "name": "go-urn",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-      "group": "github.com/kisielk",
-      "name": "errcheck",
-      "version": "v1.2.0",
-      "purl": "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/mod@v0.2.0",
-      "group": "golang.org/x",
-      "name": "mod",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/golang.org/x/mod@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-      "group": "golang.org/x",
-      "name": "crypto",
-      "version": "v0.0.0-20210220033148-5ea612d1eb83",
-      "purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-      "group": "golang.org/x",
-      "name": "tools",
-      "version": "v0.0.0-20200509030707-2212a7e161a5",
-      "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-      "group": "github.com/btcsuite",
-      "name": "btcd",
-      "version": "v0.0.0-20190523000118-16327141da8c",
-      "purl": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-      "group": "github.com/coreos",
-      "name": "go-semver",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/github.com/coreos/go-semver@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-flow-metrics",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-      "group": "github.com/minio",
-      "name": "sha256-simd",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-      "group": "github.com/spacemonkeygo",
-      "name": "openssl",
-      "version": "v0.0.0-20181017203307-c2dcc5cca94a",
-      "purl": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "group": "github.com/hashicorp",
-      "name": "golang-lru",
-      "version": "v0.5.1",
-      "purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-      "group": "github.com/ipfs",
-      "name": "bbloom",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-ds-help",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-metrics-interface",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
-      "group": "github.com/google",
-      "name": "go-cmp",
-      "version": "v0.5.4",
-      "purl": "pkg:golang/github.com/google/go-cmp@v0.5.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-detect-race",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-      "group": "github.com/jbenet",
-      "name": "go-cienv",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-autonat",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-circuit",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-loggables",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-mplex",
-      "version": "v0.2.1",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-nat",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-netutil",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-peerstore",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-secio",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-transport-upgrader",
-      "version": "v0.1.1",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-yamux",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-      "group": "github.com/libp2p",
-      "name": "go-maddr-filter",
-      "version": "v0.0.4",
-      "purl": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-      "group": "github.com/libp2p",
-      "name": "go-stream-muxer-multistream",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-tcp-transport",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-ws-transport",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/miekg/dns@v1.1.12",
-      "group": "github.com/miekg",
-      "name": "dns",
-      "version": "v1.1.12",
-      "purl": "pkg:golang/github.com/miekg/dns@v1.1.12"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr-dns",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr-net",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-      "group": "github.com/whyrusleeping",
-      "name": "mdns",
-      "version": "v0.0.0-20180901202407-ef14215e6b30",
-      "purl": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-      "group": "github.com/multiformats",
-      "name": "go-multibase",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-      "group": "github.com/multiformats",
-      "name": "go-base32",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
-      "group": "github.com/ugorji",
-      "name": "go",
-      "version": "v1.1.7",
-      "purl": "pkg:golang/github.com/ugorji/go@v1.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-      "group": "github.com/ugorji/go",
-      "name": "codec",
-      "version": "v1.1.7",
-      "purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-mplex",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-stream-muxer",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-      "group": "howett.net",
-      "name": "plist",
-      "version": "v0.0.0-20181124034731-591f970eefbb",
-      "purl": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-      "group": "github.com/jessevdk",
-      "name": "go-flags",
-      "version": "v1.4.0",
-      "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
-      "group": "github.com/kr",
-      "name": "pretty",
-      "version": "v0.2.1",
-      "purl": "pkg:golang/github.com/kr/pretty@v0.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-      "group": "gopkg.in",
-      "name": "check.v1",
-      "version": "v1.0.0-20180628173108-788fd7840127",
-      "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-      "group": "gopkg.in",
-      "name": "yaml.v2",
-      "version": "v2.2.8",
-      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-      "group": "github.com/go-playground/validator",
-      "name": "v10",
-      "version": "v10.2.0",
-      "purl": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-      "group": "github.com/go-playground/assert",
-      "name": "v2",
-      "version": "v2.0.1",
-      "purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
-      "group": "github.com/go-playground",
-      "name": "locales",
-      "version": "v0.13.0",
-      "purl": "pkg:golang/github.com/go-playground/locales@v0.13.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-      "group": "github.com/go-playground",
-      "name": "universal-translator",
-      "version": "v0.17.0",
-      "purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-      "group": "github.com/libp2p",
-      "name": "go-nat",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-      "group": "github.com/whyrusleeping",
-      "name": "go-notifier",
-      "version": "v0.0.0-20170827234753-097c5d47330f",
-      "purl": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipld/go-car@v0.3.0",
-      "group": "github.com/ipld",
-      "name": "go-car",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/github.com/ipld/go-car@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-      "group": "github.com/ipfs",
-      "name": "go-ipld-cbor",
-      "version": "v0.0.5",
-      "purl": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-      "group": "github.com/ipfs",
-      "name": "go-ipld-format",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-      "group": "github.com/ipfs",
-      "name": "go-merkledag",
-      "version": "v0.3.2",
-      "purl": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-      "group": "go.elastic.co",
-      "name": "fastjson",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/go.elastic.co/fastjson@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
-      "group": "github.com/pkg",
-      "name": "errors",
-      "version": "v0.8.1",
-      "purl": "pkg:golang/github.com/pkg/errors@v0.8.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-      "group": "github.com/valyala",
-      "name": "fasttemplate",
-      "version": "v1.2.1",
-      "purl": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-      "group": "github.com/valyala",
-      "name": "bytebufferpool",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "group": "github.com/davecgh",
-      "name": "go-spew",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "group": "github.com/pmezard",
-      "name": "go-difflib",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "group": "github.com/stretchr",
-      "name": "objx",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/stretchr/objx@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
-      "group": "github.com/labstack",
-      "name": "gommon",
-      "version": "v0.3.0",
-      "purl": "pkg:golang/github.com/labstack/gommon@v0.3.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-      "group": "github.com/mattn",
-      "name": "go-isatty",
-      "version": "v0.0.12",
-      "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-msgio",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.1",
-      "group": "github.com/google",
-      "name": "uuid",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/google/uuid@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-      "group": "golang.org/x",
-      "name": "term",
-      "version": "v0.0.0-20201117132131-f5c789dd3221",
-      "purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-      "group": "golang.org/x",
-      "name": "sys",
-      "version": "v0.0.0-20210309074719-68d13333faf2",
-      "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-      "group": "github.com/prometheus",
-      "name": "procfs",
-      "version": "v0.0.3",
-      "purl": "pkg:golang/github.com/prometheus/procfs@v0.0.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-      "group": "golang.org/x",
-      "name": "sync",
-      "version": "v0.0.0-20190911185100-cd5d95a43a6e",
-      "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-addr-util",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-      "group": "github.com/whyrusleeping",
-      "name": "mafmt",
-      "version": "v1.2.8",
-      "purl": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-      "group": "github.com/whyrusleeping",
-      "name": "multiaddr-filter",
-      "version": "v0.0.0-20160516205228-e903e4adabd7",
-      "purl": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-      "group": "github.com/klauspost/cpuid",
-      "name": "v2",
-      "version": "v2.0.4",
-      "purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-      "group": "github.com/gorilla",
-      "name": "websocket",
-      "version": "v1.4.0",
-      "purl": "pkg:golang/github.com/gorilla/websocket@v1.4.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
-      "group": "github.com/gin-gonic",
-      "name": "gin",
-      "version": "v1.6.0",
-      "purl": "pkg:golang/github.com/gin-gonic/gin@v1.6.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
-      "group": "github.com/labstack/echo",
-      "name": "v4",
-      "version": "v4.1.18-0.20201215153152-4422e3b66b9f",
-      "purl": "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
-      "group": "github.com/russellhaering",
-      "name": "goxmldsig",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/go.elastic.co/apm@v1.11.0",
-      "group": "go.elastic.co",
-      "name": "apm",
-      "version": "v1.11.0",
-      "purl": "pkg:golang/go.elastic.co/apm@v1.11.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-      "group": "github.com/elastic",
-      "name": "go-sysinfo",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-      "group": "github.com/elastic",
-      "name": "go-windows",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/elastic/go-windows@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-      "group": "github.com/joeshaw",
-      "name": "multierror",
-      "version": "v0.0.0-20140124173710-69b34d4ec901",
-      "purl": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-      "group": "github.com/minio",
-      "name": "blake2b-simd",
-      "version": "v0.0.0-20160723061019-3f5f724cb5b1",
-      "purl": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-      "group": "github.com/spaolacci",
-      "name": "murmur3",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
-      "group": "github.com/golang",
-      "name": "protobuf",
-      "version": "v1.3.3",
-      "purl": "pkg:golang/github.com/golang/protobuf@v1.3.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-      "group": "google.golang.org",
-      "name": "genproto",
-      "version": "v0.0.0-20180831171423-11092d34479b",
-      "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-      "group": "github.com/ipfs",
-      "name": "go-ds-badger",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-crypto",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-peer",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-      "group": "github.com/whyrusleeping",
-      "name": "go-keyspace",
-      "version": "v0.0.0-20160322163242-5b898ac5add1",
-      "purl": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-libp2p-record",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-      "group": "github.com/andreasbriese",
-      "name": "bbloom",
-      "version": "v0.0.0-20180913140656-343706a395b7",
-      "purl": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-      "group": "github.com/kubuxu",
-      "name": "go-os-helper",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-      "group": "github.com/dgraph-io",
-      "name": "badger",
-      "version": "v1.5.5-0.20190226225317-8115aed38f8f",
-      "purl": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-      "group": "github.com/dgryski",
-      "name": "go-farm",
-      "version": "v0.0.0-20190104051053-3adb47b1fb0f",
-      "purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-      "group": "github.com/dustin",
-      "name": "go-humanize",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-      "group": "github.com/spacemonkeygo",
-      "name": "spacelog",
-      "version": "v0.0.0-20180420211403-2296661a0572",
-      "purl": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-      "group": "github.com/libp2p",
-      "name": "go-reuseport",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-      "group": "github.com/libp2p",
-      "name": "go-reuseport-transport",
-      "version": "v0.0.2",
-      "purl": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-      "group": "github.com/multiformats",
-      "name": "go-multiaddr-fmt",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-      "group": "github.com/go-check",
-      "name": "check",
-      "version": "v0.0.0-20180628173108-788fd7840127",
-      "purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-      "group": "github.com/frankban",
-      "name": "quicktest",
-      "version": "v1.11.3",
-      "purl": "pkg:golang/github.com/frankban/quicktest@v1.11.3"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-      "group": "github.com/smartystreets",
-      "name": "goconvey",
-      "version": "v1.6.4",
-      "purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-      "group": "github.com/warpfork",
-      "name": "go-wish",
-      "version": "v0.0.0-20200122115046-b9ea61034e4a",
-      "purl": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/text@v0.1.0",
-      "group": "github.com/kr",
-      "name": "text",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/kr/text@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
-      "group": "github.com/aead",
-      "name": "siphash",
-      "version": "v1.0.1",
-      "purl": "pkg:golang/github.com/aead/siphash@v1.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-      "group": "github.com/btcsuite",
-      "name": "btclog",
-      "version": "v0.0.0-20170628155309-84c8d2346e9f",
-      "purl": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-      "group": "github.com/btcsuite",
-      "name": "btcutil",
-      "version": "v0.0.0-20190425235716-9e5f4b9a998d",
-      "purl": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-      "group": "github.com/btcsuite",
-      "name": "go-socks",
-      "version": "v0.0.0-20170105172521-4720035b7bfd",
-      "purl": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-      "group": "github.com/btcsuite",
-      "name": "goleveldb",
-      "version": "v0.0.0-20160330041536-7834afc9e8cd",
-      "purl": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-      "group": "github.com/btcsuite",
-      "name": "snappy-go",
-      "version": "v0.0.0-20151229074030-0bdef8d06723",
-      "purl": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-      "group": "github.com/btcsuite",
-      "name": "websocket",
-      "version": "v0.0.0-20150119174127-31079b680792",
-      "purl": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-      "group": "github.com/btcsuite",
-      "name": "winsvc",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-      "group": "github.com/jrick",
-      "name": "logrotate",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/jrick/logrotate@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-      "group": "github.com/kkdai",
-      "name": "bstream",
-      "version": "v0.0.0-20161212061736-f391b8402d23",
-      "purl": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-      "group": "github.com/onsi",
-      "name": "ginkgo",
-      "version": "v1.8.0",
-      "purl": "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
-      "group": "github.com/onsi",
-      "name": "gomega",
-      "version": "v1.5.0",
-      "purl": "pkg:golang/github.com/onsi/gomega@v1.5.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1",
-      "group": "github.com/kr",
-      "name": "pty",
-      "version": "v1.1.1",
-      "purl": "pkg:golang/github.com/kr/pty@v1.1.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-      "group": "github.com/jbenet",
-      "name": "go-temp-err-catcher",
-      "version": "v0.0.0-20150120210811-aac704a3f4f2",
-      "purl": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
-      "group": "github.com/armon",
-      "name": "go-radix",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/armon/go-radix@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
-      "group": "github.com/cucumber",
-      "name": "godog",
-      "version": "v0.8.1",
-      "purl": "pkg:golang/github.com/cucumber/godog@v0.8.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-      "group": "github.com/santhosh-tekuri",
-      "name": "jsonschema",
-      "version": "v1.2.4",
-      "purl": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-      "group": "github.com/whyrusleeping",
-      "name": "cbor-gen",
-      "version": "v0.0.0-20200123233031-1cdf64d27158",
-      "purl": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
-      "group": "github.com/beevik",
-      "name": "etree",
-      "version": "v1.1.0",
-      "purl": "pkg:golang/github.com/beevik/etree@v1.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-      "group": "github.com/jonboulle",
-      "name": "clockwork",
-      "version": "v0.2.0",
-      "purl": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-      "group": "github.com/fsnotify",
-      "name": "fsnotify",
-      "version": "v1.4.7",
-      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-      "group": "github.com/hpcloud",
-      "name": "tail",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-      "group": "gopkg.in",
-      "name": "fsnotify.v1",
-      "version": "v1.4.7",
-      "purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-      "group": "gopkg.in",
-      "name": "tomb.v1",
-      "version": "v1.0.0-20141024135613-dd632973f1e7",
-      "purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
-      "group": "github.com/json-iterator",
-      "name": "go",
-      "version": "v1.1.9",
-      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.9"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
-      "group": "github.com/google",
-      "name": "gofuzz",
-      "version": "v1.0.0",
-      "purl": "pkg:golang/github.com/google/gofuzz@v1.0.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-      "group": "github.com/modern-go",
-      "name": "concurrent",
-      "version": "v0.0.0-20180228061459-e0a39a4cb421",
-      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-      "group": "github.com/modern-go",
-      "name": "reflect2",
-      "version": "v0.0.0-20180701023420-4b7aa43c6742",
-      "purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-      "group": "github.com/gopherjs",
-      "name": "gopherjs",
-      "version": "v0.0.0-20181017120253-0766667cb4d1",
-      "purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-      "group": "github.com/jtolds",
-      "name": "gls",
-      "version": "v4.20.0+incompatible",
-      "purl": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-      "group": "github.com/smartystreets",
-      "name": "assertions",
-      "version": "v0.0.0-20180927180507-b2de0cb4f26d",
-      "purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-      "group": "github.com/golang",
-      "name": "snappy",
-      "version": "v0.0.0-20180518054509-2e65f85255db",
-      "purl": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-      "group": "github.com/cskr",
-      "name": "pubsub",
-      "version": "v1.0.2",
-      "purl": "pkg:golang/github.com/cskr/pubsub@v1.0.2"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-      "group": "github.com/ipfs",
-      "name": "go-peertaskqueue",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-      "group": "github.com/libp2p",
-      "name": "go-testutil",
-      "version": "v0.1.0",
-      "purl": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-      "group": "github.com/jackpal",
-      "name": "gateway",
-      "version": "v1.0.5",
-      "purl": "pkg:golang/github.com/jackpal/gateway@v1.0.5"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-      "group": "github.com/jackpal",
-      "name": "go-nat-pmp",
-      "version": "v1.0.1",
-      "purl": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-      "group": "github.com/koron",
-      "name": "go-ssdp",
-      "version": "v0.0.0-20180514024734-4a0ed625a78b",
-      "purl": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-      "group": "github.com/dgrijalva",
-      "name": "jwt-go",
-      "version": "v3.2.0+incompatible",
-      "purl": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-      "group": "github.com/ipfs",
-      "name": "go-ipfs-pq",
-      "version": "v0.0.1",
-      "purl": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
-    }
-  ],
-  "dependencies": [
-    {
-      "ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
-        "pkg:golang/github.com/ipld/go-car@v0.3.0",
-        "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
-        "pkg:golang/github.com/miekg/dns@v1.1.12",
-        "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
-        "pkg:golang/go.elastic.co/apm@v1.11.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-      "dependsOn": [
-        "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-        "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-        "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-        "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-      "dependsOn": [
-        "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-        "pkg:golang/github.com/stretchr/objx@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/text@v0.3.3",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-      "dependsOn": [
-        "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/google/uuid@v1.1.1",
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-      "dependsOn": [
-        "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-        "pkg:golang/github.com/google/uuid@v1.1.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/kr/pretty@v0.2.1",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-      "dependsOn": [
-        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/github.com/onsi/gomega@v1.5.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/mod@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
-      "dependsOn": [
-        "pkg:golang/github.com/aead/siphash@v1.0.1",
-        "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-        "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-        "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-        "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-        "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-        "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-        "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-        "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-        "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/github.com/onsi/gomega@v1.5.0",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
-      "dependsOn": [
-        "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-        "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-        "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-        "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-        "pkg:golang/github.com/miekg/dns@v1.1.12",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
-        "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/google/uuid@v1.1.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-        "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-        "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-        "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/github.com/onsi/gomega@v1.5.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/miekg/dns@v1.1.12",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/mr-tron/base58@v1.2.0",
-        "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-      "dependsOn": [
-        "pkg:golang/github.com/ugorji/go@v1.1.7"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
-      "dependsOn": [
-        "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-        "pkg:golang/github.com/kr/pretty@v0.2.1",
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/text@v0.1.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
-      "dependsOn": [
-        "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-        "pkg:golang/github.com/go-playground/locales@v0.13.0",
-        "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-        "pkg:golang/github.com/leodido/go-urn@v1.2.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
-      "dependsOn": [
-        "pkg:golang/github.com/go-playground/locales@v0.13.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/huin/goupnp@v1.0.0",
-        "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-        "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-        "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipld/go-car@v0.3.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-        "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-        "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
-        "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
-        "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
-        "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-        "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
-        "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
-        "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
-        "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-      "dependsOn": [
-        "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
-      "dependsOn": [
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/uuid@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
-      ]
-    },
-    {
-      "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
-        "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-        "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/json-iterator/go@v1.1.9",
-        "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
-      "dependsOn": [
-        "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-        "pkg:golang/github.com/labstack/gommon@v0.3.0",
-        "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
-        "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/beevik/etree@v1.1.0",
-        "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/go.elastic.co/apm@v1.11.0",
-      "dependsOn": [
-        "pkg:golang/github.com/armon/go-radix@v1.0.0",
-        "pkg:golang/github.com/cucumber/godog@v0.8.1",
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-        "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/go.elastic.co/fastjson@v1.1.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
-      "dependsOn": [
-        "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-        "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/prometheus/procfs@v0.0.3",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
-      "dependsOn": [
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-        "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
-      ]
-    },
-    {
-      "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-        "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-        "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-        "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-        "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
-        "pkg:golang/github.com/pkg/errors@v0.8.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/gogo/protobuf@v1.3.1",
-        "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/pkg/errors@v0.8.1",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-log@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
-      "dependsOn": [
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/github.com/kr/pretty@v0.2.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
-      "dependsOn": [
-        "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-        "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-        "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-        "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/text@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/kr/pty@v1.1.1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
-      "dependsOn": [
-        "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-        "pkg:golang/github.com/golang/protobuf@v1.3.3",
-        "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-        "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
-        "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
-        "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
-        "pkg:golang/golang.org/x/text@v0.3.3",
-        "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-        "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-        "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/kr/pty@v1.1.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
-      "dependsOn": [
-        "pkg:golang/github.com/google/go-cmp@v0.5.4",
-        "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
-        "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
-      "dependsOn": [
-        "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-        "pkg:golang/github.com/google/gofuzz@v1.0.0",
-        "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-        "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-        "pkg:golang/github.com/stretchr/testify@v1.7.0"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
-      "dependsOn": [
-        "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
-        "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
-        "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
-        "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
-      ]
-    },
-    {
-      "ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
-      "dependsOn": []
-    }
-  ]
+  "components" : [ {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-verifcid",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+    "group" : "github.com/ipfs",
+    "name" : "go-cid",
+    "version" : "v0.0.7",
+    "purl" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+    "group" : "github.com/multiformats",
+    "name" : "go-multihash",
+    "version" : "v0.0.15",
+    "purl" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-conn-security-multistream",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-core",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-testing",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+    "group" : "github.com/multiformats",
+    "name" : "go-multistream",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-discovery",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-log",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-log@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-blankhost",
+    "version" : "v0.1.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-swarm",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+    "group" : "github.com/gogo",
+    "name" : "protobuf",
+    "version" : "v1.3.1",
+    "purl" : "pkg:golang/github.com/gogo/protobuf@v1.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+    "group" : "github.com/mattn",
+    "name" : "go-colorable",
+    "version" : "v0.1.7",
+    "purl" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+    "group" : "github.com/opentracing",
+    "name" : "opentracing-go",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
+    "group" : "github.com/stretchr",
+    "name" : "testify",
+    "version" : "v1.7.0",
+    "purl" : "pkg:golang/github.com/stretchr/testify@v1.7.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+    "group" : "github.com/whyrusleeping",
+    "name" : "go-logging",
+    "version" : "v0.0.0-20170515211332-0457bb6b88fc",
+    "purl" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+    "group" : "golang.org/x",
+    "name" : "net",
+    "version" : "v0.0.0-20200822124328-c89045814202",
+    "purl" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
+    "group" : "github.com/huin",
+    "name" : "goupnp",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/huin/goupnp@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+    "group" : "github.com/huin",
+    "name" : "goutil",
+    "version" : "v0.0.0-20170803182201-1ca381bf3150",
+    "purl" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/text@v0.3.3",
+    "group" : "golang.org/x",
+    "name" : "text",
+    "version" : "v0.3.3",
+    "purl" : "pkg:golang/golang.org/x/text@v0.3.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-yamux",
+    "version" : "v1.2.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-buffer-pool",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+    "group" : "github.com/ipld",
+    "name" : "go-codec-dagpb",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+    "group" : "github.com/ipld",
+    "name" : "go-ipld-prime",
+    "version" : "v0.9.0",
+    "purl" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+    "group" : "github.com/mr-tron",
+    "name" : "base58",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/mr-tron/base58@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+    "group" : "github.com/multiformats",
+    "name" : "go-varint",
+    "version" : "v0.0.6",
+    "purl" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+    "group" : "github.com/polydawn",
+    "name" : "refmt",
+    "version" : "v0.0.0-20201211092308-30ac6d18308e",
+    "purl" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "group" : "golang.org/x",
+    "name" : "xerrors",
+    "version" : "v0.0.0-20200804184101-5ec99f83aff1",
+    "purl" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-blockservice",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-bitswap",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+    "group" : "github.com/ipfs",
+    "name" : "go-block-format",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-datastore",
+    "version" : "v0.3.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-blockstore",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-blocksutil",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-delay",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-exchange-interface",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-exchange-offline",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-routing",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-util",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "group" : "github.com/gin-contrib",
+    "name" : "sse",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ds-leveldb",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+    "group" : "github.com/jbenet",
+    "name" : "goprocess",
+    "version" : "v0.1.3",
+    "purl" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+    "group" : "github.com/syndtr",
+    "name" : "goleveldb",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+    "group" : "github.com/leodido",
+    "name" : "go-urn",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
+    "group" : "golang.org/x",
+    "name" : "mod",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/golang.org/x/mod@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+    "group" : "golang.org/x",
+    "name" : "crypto",
+    "version" : "v0.0.0-20210220033148-5ea612d1eb83",
+    "purl" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+    "group" : "golang.org/x",
+    "name" : "tools",
+    "version" : "v0.0.0-20200509030707-2212a7e161a5",
+    "purl" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+    "group" : "github.com/kisielk",
+    "name" : "errcheck",
+    "version" : "v1.2.0",
+    "purl" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "group" : "github.com/kisielk",
+    "name" : "gotool",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-detect-race",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+    "group" : "github.com/jbenet",
+    "name" : "go-cienv",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-autonat",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-circuit",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-loggables",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-mplex",
+    "version" : "v0.2.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-nat",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-netutil",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-peerstore",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-secio",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-transport-upgrader",
+    "version" : "v0.1.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-yamux",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+    "group" : "github.com/libp2p",
+    "name" : "go-maddr-filter",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-stream-muxer-multistream",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-tcp-transport",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-ws-transport",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/miekg/dns@v1.1.12",
+    "group" : "github.com/miekg",
+    "name" : "dns",
+    "version" : "v1.1.12",
+    "purl" : "pkg:golang/github.com/miekg/dns@v1.1.12"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr-dns",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr-net",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+    "group" : "github.com/whyrusleeping",
+    "name" : "mdns",
+    "version" : "v0.0.0-20180901202407-ef14215e6b30",
+    "purl" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
+    "group" : "github.com/google",
+    "name" : "go-cmp",
+    "version" : "v0.5.4",
+    "purl" : "pkg:golang/github.com/google/go-cmp@v0.5.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "group" : "github.com/hashicorp",
+    "name" : "golang-lru",
+    "version" : "v0.5.1",
+    "purl" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+    "group" : "github.com/ipfs",
+    "name" : "bbloom",
+    "version" : "v0.0.4",
+    "purl" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-ds-help",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-metrics-interface",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+    "group" : "github.com/btcsuite",
+    "name" : "btcd",
+    "version" : "v0.0.0-20190523000118-16327141da8c",
+    "purl" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+    "group" : "github.com/coreos",
+    "name" : "go-semver",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/github.com/coreos/go-semver@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-flow-metrics",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+    "group" : "github.com/minio",
+    "name" : "sha256-simd",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+    "group" : "github.com/spacemonkeygo",
+    "name" : "openssl",
+    "version" : "v0.0.0-20181017203307-c2dcc5cca94a",
+    "purl" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+    "group" : "github.com/multiformats",
+    "name" : "go-multibase",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+    "group" : "github.com/multiformats",
+    "name" : "go-base32",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+    "group" : "github.com/multiformats",
+    "name" : "go-base36",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+    "group" : "github.com/ugorji",
+    "name" : "go",
+    "version" : "v1.1.7",
+    "purl" : "pkg:golang/github.com/ugorji/go@v1.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+    "group" : "github.com/ugorji/go",
+    "name" : "codec",
+    "version" : "v1.1.7",
+    "purl" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-mplex",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-stream-muxer",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+    "group" : "howett.net",
+    "name" : "plist",
+    "version" : "v0.0.0-20181124034731-591f970eefbb",
+    "purl" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+    "group" : "github.com/jessevdk",
+    "name" : "go-flags",
+    "version" : "v1.4.0",
+    "purl" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
+    "group" : "github.com/kr",
+    "name" : "pretty",
+    "version" : "v0.2.1",
+    "purl" : "pkg:golang/github.com/kr/pretty@v0.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+    "group" : "gopkg.in",
+    "name" : "check.v1",
+    "version" : "v1.0.0-20180628173108-788fd7840127",
+    "purl" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+    "group" : "gopkg.in",
+    "name" : "yaml.v2",
+    "version" : "v2.2.8",
+    "purl" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+    "group" : "github.com/go-playground/validator",
+    "name" : "v10",
+    "version" : "v10.2.0",
+    "purl" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+    "group" : "github.com/go-playground/assert",
+    "name" : "v2",
+    "version" : "v2.0.1",
+    "purl" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+    "group" : "github.com/go-playground",
+    "name" : "locales",
+    "version" : "v0.13.0",
+    "purl" : "pkg:golang/github.com/go-playground/locales@v0.13.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+    "group" : "github.com/go-playground",
+    "name" : "universal-translator",
+    "version" : "v0.17.0",
+    "purl" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+    "group" : "github.com/libp2p",
+    "name" : "go-nat",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+    "group" : "github.com/whyrusleeping",
+    "name" : "go-notifier",
+    "version" : "v0.0.0-20170827234753-097c5d47330f",
+    "purl" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipld/go-car@v0.3.0",
+    "group" : "github.com/ipld",
+    "name" : "go-car",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/github.com/ipld/go-car@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipld-cbor",
+    "version" : "v0.0.5",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipld-format",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+    "group" : "github.com/ipfs",
+    "name" : "go-merkledag",
+    "version" : "v0.3.2",
+    "purl" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+    "group" : "go.elastic.co",
+    "name" : "fastjson",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/go.elastic.co/fastjson@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
+    "group" : "github.com/pkg",
+    "name" : "errors",
+    "version" : "v0.8.1",
+    "purl" : "pkg:golang/github.com/pkg/errors@v0.8.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+    "group" : "github.com/valyala",
+    "name" : "fasttemplate",
+    "version" : "v1.2.1",
+    "purl" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+    "group" : "github.com/valyala",
+    "name" : "bytebufferpool",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
+    "group" : "github.com/labstack",
+    "name" : "gommon",
+    "version" : "v0.3.0",
+    "purl" : "pkg:golang/github.com/labstack/gommon@v0.3.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+    "group" : "github.com/mattn",
+    "name" : "go-isatty",
+    "version" : "v0.0.12",
+    "purl" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "group" : "github.com/davecgh",
+    "name" : "go-spew",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "group" : "github.com/pmezard",
+    "name" : "go-difflib",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "group" : "github.com/stretchr",
+    "name" : "objx",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/stretchr/objx@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-msgio",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
+    "group" : "github.com/google",
+    "name" : "uuid",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/google/uuid@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+    "group" : "golang.org/x",
+    "name" : "term",
+    "version" : "v0.0.0-20201117132131-f5c789dd3221",
+    "purl" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+    "group" : "golang.org/x",
+    "name" : "sys",
+    "version" : "v0.0.0-20210309074719-68d13333faf2",
+    "purl" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-addr-util",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+    "group" : "github.com/whyrusleeping",
+    "name" : "mafmt",
+    "version" : "v1.2.8",
+    "purl" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+    "group" : "github.com/whyrusleeping",
+    "name" : "multiaddr-filter",
+    "version" : "v0.0.0-20160516205228-e903e4adabd7",
+    "purl" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+    "group" : "github.com/prometheus",
+    "name" : "procfs",
+    "version" : "v0.0.3",
+    "purl" : "pkg:golang/github.com/prometheus/procfs@v0.0.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+    "group" : "golang.org/x",
+    "name" : "sync",
+    "version" : "v0.0.0-20190911185100-cd5d95a43a6e",
+    "purl" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+    "group" : "github.com/klauspost/cpuid",
+    "name" : "v2",
+    "version" : "v2.0.4",
+    "purl" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+    "group" : "github.com/gorilla",
+    "name" : "websocket",
+    "version" : "v1.4.0",
+    "purl" : "pkg:golang/github.com/gorilla/websocket@v1.4.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
+    "group" : "github.com/gin-gonic",
+    "name" : "gin",
+    "version" : "v1.6.0",
+    "purl" : "pkg:golang/github.com/gin-gonic/gin@v1.6.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
+    "group" : "github.com/labstack/echo",
+    "name" : "v4",
+    "version" : "v4.1.18-0.20201215153152-4422e3b66b9f",
+    "purl" : "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
+    "group" : "github.com/russellhaering",
+    "name" : "goxmldsig",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/go.elastic.co/apm@v1.11.0",
+    "group" : "go.elastic.co",
+    "name" : "apm",
+    "version" : "v1.11.0",
+    "purl" : "pkg:golang/go.elastic.co/apm@v1.11.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+    "group" : "github.com/elastic",
+    "name" : "go-sysinfo",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+    "group" : "github.com/elastic",
+    "name" : "go-windows",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/elastic/go-windows@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+    "group" : "github.com/joeshaw",
+    "name" : "multierror",
+    "version" : "v0.0.0-20140124173710-69b34d4ec901",
+    "purl" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+    "group" : "github.com/gxed/hashland",
+    "name" : "keccakpg",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+    "group" : "github.com/gxed/hashland",
+    "name" : "murmur3",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+    "group" : "github.com/minio",
+    "name" : "blake2b-simd",
+    "version" : "v0.0.0-20160723061019-3f5f724cb5b1",
+    "purl" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+    "group" : "github.com/spaolacci",
+    "name" : "murmur3",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+    "group" : "github.com/golang",
+    "name" : "protobuf",
+    "version" : "v1.3.3",
+    "purl" : "pkg:golang/github.com/golang/protobuf@v1.3.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+    "group" : "google.golang.org",
+    "name" : "genproto",
+    "version" : "v0.0.0-20180831171423-11092d34479b",
+    "purl" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+    "group" : "github.com/ipfs",
+    "name" : "go-ds-badger",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-crypto",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-peer",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+    "group" : "github.com/whyrusleeping",
+    "name" : "go-keyspace",
+    "version" : "v0.0.0-20160322163242-5b898ac5add1",
+    "purl" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-libp2p-record",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+    "group" : "github.com/andreasbriese",
+    "name" : "bbloom",
+    "version" : "v0.0.0-20180913140656-343706a395b7",
+    "purl" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+    "group" : "github.com/kubuxu",
+    "name" : "go-os-helper",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+    "group" : "github.com/dgraph-io",
+    "name" : "badger",
+    "version" : "v1.5.5-0.20190226225317-8115aed38f8f",
+    "purl" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+    "group" : "github.com/dgryski",
+    "name" : "go-farm",
+    "version" : "v0.0.0-20190104051053-3adb47b1fb0f",
+    "purl" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+    "group" : "github.com/dustin",
+    "name" : "go-humanize",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+    "group" : "github.com/spacemonkeygo",
+    "name" : "spacelog",
+    "version" : "v0.0.0-20180420211403-2296661a0572",
+    "purl" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+    "group" : "github.com/libp2p",
+    "name" : "go-reuseport",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+    "group" : "github.com/libp2p",
+    "name" : "go-reuseport-transport",
+    "version" : "v0.0.2",
+    "purl" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+    "group" : "github.com/multiformats",
+    "name" : "go-multiaddr-fmt",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+    "group" : "github.com/frankban",
+    "name" : "quicktest",
+    "version" : "v1.11.3",
+    "purl" : "pkg:golang/github.com/frankban/quicktest@v1.11.3"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+    "group" : "github.com/go-check",
+    "name" : "check",
+    "version" : "v0.0.0-20180628173108-788fd7840127",
+    "purl" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+    "group" : "github.com/smartystreets",
+    "name" : "goconvey",
+    "version" : "v1.6.4",
+    "purl" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+    "group" : "github.com/warpfork",
+    "name" : "go-wish",
+    "version" : "v0.0.0-20200122115046-b9ea61034e4a",
+    "purl" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+    "group" : "github.com/whyrusleeping",
+    "name" : "cbor-gen",
+    "version" : "v0.0.0-20200123233031-1cdf64d27158",
+    "purl" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/text@v0.1.0",
+    "group" : "github.com/kr",
+    "name" : "text",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/kr/text@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
+    "group" : "github.com/aead",
+    "name" : "siphash",
+    "version" : "v1.0.1",
+    "purl" : "pkg:golang/github.com/aead/siphash@v1.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+    "group" : "github.com/btcsuite",
+    "name" : "btclog",
+    "version" : "v0.0.0-20170628155309-84c8d2346e9f",
+    "purl" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+    "group" : "github.com/btcsuite",
+    "name" : "btcutil",
+    "version" : "v0.0.0-20190425235716-9e5f4b9a998d",
+    "purl" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+    "group" : "github.com/btcsuite",
+    "name" : "go-socks",
+    "version" : "v0.0.0-20170105172521-4720035b7bfd",
+    "purl" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+    "group" : "github.com/btcsuite",
+    "name" : "goleveldb",
+    "version" : "v0.0.0-20160330041536-7834afc9e8cd",
+    "purl" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+    "group" : "github.com/btcsuite",
+    "name" : "snappy-go",
+    "version" : "v0.0.0-20151229074030-0bdef8d06723",
+    "purl" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+    "group" : "github.com/btcsuite",
+    "name" : "websocket",
+    "version" : "v0.0.0-20150119174127-31079b680792",
+    "purl" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+    "group" : "github.com/btcsuite",
+    "name" : "winsvc",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+    "group" : "github.com/jrick",
+    "name" : "logrotate",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/jrick/logrotate@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+    "group" : "github.com/kkdai",
+    "name" : "bstream",
+    "version" : "v0.0.0-20161212061736-f391b8402d23",
+    "purl" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+    "group" : "github.com/onsi",
+    "name" : "ginkgo",
+    "version" : "v1.8.0",
+    "purl" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
+    "group" : "github.com/onsi",
+    "name" : "gomega",
+    "version" : "v1.5.0",
+    "purl" : "pkg:golang/github.com/onsi/gomega@v1.5.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "group" : "github.com/kr",
+    "name" : "pty",
+    "version" : "v1.1.1",
+    "purl" : "pkg:golang/github.com/kr/pty@v1.1.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+    "group" : "github.com/jbenet",
+    "name" : "go-temp-err-catcher",
+    "version" : "v0.0.0-20150120210811-aac704a3f4f2",
+    "purl" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
+    "group" : "github.com/armon",
+    "name" : "go-radix",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/armon/go-radix@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
+    "group" : "github.com/cucumber",
+    "name" : "godog",
+    "version" : "v0.8.1",
+    "purl" : "pkg:golang/github.com/cucumber/godog@v0.8.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+    "group" : "github.com/santhosh-tekuri",
+    "name" : "jsonschema",
+    "version" : "v1.2.4",
+    "purl" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+    "group" : "github.com/yuin",
+    "name" : "goldmark",
+    "version" : "v1.1.27",
+    "purl" : "pkg:golang/github.com/yuin/goldmark@v1.1.27"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
+    "group" : "github.com/beevik",
+    "name" : "etree",
+    "version" : "v1.1.0",
+    "purl" : "pkg:golang/github.com/beevik/etree@v1.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+    "group" : "github.com/jonboulle",
+    "name" : "clockwork",
+    "version" : "v0.2.0",
+    "purl" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+    "group" : "github.com/fsnotify",
+    "name" : "fsnotify",
+    "version" : "v1.4.7",
+    "purl" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+    "group" : "github.com/hpcloud",
+    "name" : "tail",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/hpcloud/tail@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+    "group" : "gopkg.in",
+    "name" : "fsnotify.v1",
+    "version" : "v1.4.7",
+    "purl" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+    "group" : "gopkg.in",
+    "name" : "tomb.v1",
+    "version" : "v1.0.0-20141024135613-dd632973f1e7",
+    "purl" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+    "group" : "github.com/json-iterator",
+    "name" : "go",
+    "version" : "v1.1.9",
+    "purl" : "pkg:golang/github.com/json-iterator/go@v1.1.9"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+    "group" : "github.com/google",
+    "name" : "gofuzz",
+    "version" : "v1.0.0",
+    "purl" : "pkg:golang/github.com/google/gofuzz@v1.0.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+    "group" : "github.com/modern-go",
+    "name" : "concurrent",
+    "version" : "v0.0.0-20180228061459-e0a39a4cb421",
+    "purl" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+    "group" : "github.com/modern-go",
+    "name" : "reflect2",
+    "version" : "v0.0.0-20180701023420-4b7aa43c6742",
+    "purl" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+    "group" : "github.com/gopherjs",
+    "name" : "gopherjs",
+    "version" : "v0.0.0-20181017120253-0766667cb4d1",
+    "purl" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+    "group" : "github.com/jtolds",
+    "name" : "gls",
+    "version" : "v4.20.0+incompatible",
+    "purl" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+    "group" : "github.com/smartystreets",
+    "name" : "assertions",
+    "version" : "v0.0.0-20180927180507-b2de0cb4f26d",
+    "purl" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+    "group" : "github.com/golang",
+    "name" : "snappy",
+    "version" : "v0.0.0-20180518054509-2e65f85255db",
+    "purl" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+    "group" : "github.com/cskr",
+    "name" : "pubsub",
+    "version" : "v1.0.2",
+    "purl" : "pkg:golang/github.com/cskr/pubsub@v1.0.2"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+    "group" : "github.com/ipfs",
+    "name" : "go-peertaskqueue",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+    "group" : "github.com/libp2p",
+    "name" : "go-testutil",
+    "version" : "v0.1.0",
+    "purl" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+    "group" : "github.com/jackpal",
+    "name" : "gateway",
+    "version" : "v1.0.5",
+    "purl" : "pkg:golang/github.com/jackpal/gateway@v1.0.5"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+    "group" : "github.com/jackpal",
+    "name" : "go-nat-pmp",
+    "version" : "v1.0.1",
+    "purl" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+    "group" : "github.com/koron",
+    "name" : "go-ssdp",
+    "version" : "v0.0.0-20180514024734-4a0ed625a78b",
+    "purl" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+    "group" : "github.com/dgrijalva",
+    "name" : "jwt-go",
+    "version" : "v3.2.0+incompatible",
+    "purl" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
+  }, {
+    "type" : "library",
+    "bom-ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+    "group" : "github.com/ipfs",
+    "name" : "go-ipfs-pq",
+    "version" : "v0.0.1",
+    "purl" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
+  } ],
+  "dependencies" : [ {
+    "ref" : "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/gin-gonic/gin@v1.6.0", "pkg:golang/github.com/ipld/go-car@v0.3.0", "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f", "pkg:golang/github.com/miekg/dns@v1.1.12", "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0", "pkg:golang/go.elastic.co/apm@v1.11.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multibase@v0.0.3", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+    "dependsOn" : [ "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1", "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1", "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/github.com/spaolacci/murmur3@v1.1.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c", "pkg:golang/github.com/coreos/go-semver@v0.3.0", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8", "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+    "dependsOn" : [ "pkg:golang/github.com/kisielk/errcheck@v1.2.0", "pkg:golang/github.com/kisielk/gotool@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/testify@v1.7.0",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/pmezard/go-difflib@v1.0.0", "pkg:golang/github.com/stretchr/objx@v0.1.0", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/huin/goupnp@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/text@v0.3.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0", "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-varint@v0.0.6", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+    "dependsOn" : [ "pkg:golang/github.com/frankban/quicktest@v1.11.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/cskr/pubsub@v1.0.2", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-testutil@v0.1.0", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+    "dependsOn" : [ "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127", "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/bbloom@v0.0.4", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/syndtr/goleveldb@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+    "dependsOn" : [ "pkg:golang/github.com/jbenet/go-cienv@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/mod@v0.2.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+    "dependsOn" : [ "pkg:golang/github.com/yuin/goldmark@v1.1.27", "pkg:golang/golang.org/x/mod@v0.2.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/kisielk/gotool@v1.0.0", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4", "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0", "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0", "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0", "pkg:golang/github.com/miekg/dns@v1.1.12", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0", "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/google/uuid@v1.1.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-mplex@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-cienv@v0.1.0", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/libp2p/go-nat@v0.0.3", "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2", "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-msgio@v0.0.2", "pkg:golang/github.com/minio/sha256-simd@v1.0.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-yamux@v1.2.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multistream@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gorilla/websocket@v1.4.0", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/miekg/dns@v1.1.12",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/go-cmp@v0.5.4",
+    "dependsOn" : [ "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/multiformats/go-base32@v0.0.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+    "dependsOn" : [ "pkg:golang/github.com/aead/siphash@v1.0.1", "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f", "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d", "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd", "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd", "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723", "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792", "pkg:golang/github.com/btcsuite/winsvc@v1.0.0", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/jrick/logrotate@v1.0.0", "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/github.com/onsi/gomega@v1.5.0", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83" ]
+  }, {
+    "ref" : "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4" ]
+  }, {
+    "ref" : "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+    "dependsOn" : [ "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/mr-tron/base58@v1.2.0", "pkg:golang/github.com/multiformats/go-base32@v0.0.3", "pkg:golang/github.com/multiformats/go-base36@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go@v1.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/ugorji/go/codec@v1.1.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+    "dependsOn" : [ "pkg:golang/github.com/ugorji/go@v1.1.7" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+    "dependsOn" : [ "pkg:golang/github.com/jessevdk/go-flags@v1.4.0", "pkg:golang/github.com/kr/pretty@v0.2.1", "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pretty@v0.2.1",
+    "dependsOn" : [ "pkg:golang/github.com/kr/text@v0.1.0" ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+    "dependsOn" : [ "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-playground/assert/v2@v2.0.1", "pkg:golang/github.com/go-playground/locales@v0.13.0", "pkg:golang/github.com/go-playground/universal-translator@v0.17.0", "pkg:golang/github.com/leodido/go-urn@v1.2.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/locales@v0.13.0",
+    "dependsOn" : [ "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+    "dependsOn" : [ "pkg:golang/github.com/go-playground/locales@v0.13.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+    "dependsOn" : [ "pkg:golang/github.com/huin/goupnp@v1.0.0", "pkg:golang/github.com/jackpal/gateway@v1.0.5", "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1", "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipld/go-car@v0.3.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2", "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0", "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15", "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e", "pkg:golang/github.com/smartystreets/goconvey@v1.6.4", "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a", "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-block-format@v0.0.3", "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0", "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5", "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/pkg/errors@v0.8.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+    "dependsOn" : [ "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/labstack/gommon@v0.3.0",
+    "dependsOn" : [ "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/valyala/fasttemplate@v1.2.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/stretchr/objx@v0.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/uuid@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1", "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/github.com/google/go-cmp@v0.5.4" ]
+  }, {
+    "ref" : "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gin-gonic/gin@v1.6.0",
+    "dependsOn" : [ "pkg:golang/github.com/gin-contrib/sse@v0.1.0", "pkg:golang/github.com/go-playground/validator/v10@v10.2.0", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/json-iterator/go@v1.1.9", "pkg:golang/github.com/mattn/go-isatty@v0.0.12", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/ugorji/go/codec@v1.1.7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/labstack/echo/v4@v4.1.18-0.20201215153152-4422e3b66b9f",
+    "dependsOn" : [ "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible", "pkg:golang/github.com/labstack/gommon@v0.3.0", "pkg:golang/github.com/mattn/go-colorable@v0.1.7", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/github.com/valyala/fasttemplate@v1.2.1", "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3" ]
+  }, {
+    "ref" : "pkg:golang/github.com/russellhaering/goxmldsig@v1.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/beevik/etree@v1.1.0", "pkg:golang/github.com/jonboulle/clockwork@v0.2.0", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/go.elastic.co/apm@v1.11.0",
+    "dependsOn" : [ "pkg:golang/github.com/armon/go-radix@v1.0.0", "pkg:golang/github.com/cucumber/godog@v0.8.1", "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1", "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/prometheus/procfs@v0.0.3", "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/go.elastic.co/fastjson@v1.1.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+    "dependsOn" : [ "pkg:golang/github.com/elastic/go-windows@v1.0.0", "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901", "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/prometheus/procfs@v0.0.3", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb" ]
+  }, {
+    "ref" : "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/protobuf@v1.3.3",
+    "dependsOn" : [ "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b" ]
+  }, {
+    "ref" : "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7", "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1", "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f", "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f", "pkg:golang/github.com/dustin/go-humanize@v1.0.0", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/ipfs/go-datastore@v0.3.1", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/jbenet/goprocess@v0.1.3", "pkg:golang/github.com/pkg/errors@v0.8.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/gogo/protobuf@v1.3.1", "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2", "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/andreasbriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/kubuxu/go-os-helper@v0.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/pkg/errors@v0.8.1", "pkg:golang/github.com/stretchr/testify@v1.7.0", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-log@v0.0.1", "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+    "dependsOn" : [ "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/kr/pretty@v0.2.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+    "dependsOn" : [ "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1", "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible", "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d", "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5" ]
+  }, {
+    "ref" : "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+    "dependsOn" : [ "pkg:golang/github.com/google/go-cmp@v0.5.4", "pkg:golang/github.com/ipfs/go-cid@v0.0.7", "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/text@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/kr/pty@v1.1.1" ]
+  }, {
+    "ref" : "pkg:golang/github.com/aead/siphash@v1.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/onsi/gomega@v1.5.0",
+    "dependsOn" : [ "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7", "pkg:golang/github.com/golang/protobuf@v1.3.3", "pkg:golang/github.com/hpcloud/tail@v1.0.0", "pkg:golang/github.com/onsi/ginkgo@v1.8.0", "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202", "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2", "pkg:golang/golang.org/x/text@v0.3.3", "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7", "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7", "pkg:golang/gopkg.in/yaml.v2@v2.2.8" ]
+  }, {
+    "ref" : "pkg:golang/github.com/kr/pty@v1.1.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/armon/go-radix@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cucumber/godog@v0.8.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/beevik/etree@v1.1.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/json-iterator/go@v1.1.9",
+    "dependsOn" : [ "pkg:golang/github.com/davecgh/go-spew@v1.1.1", "pkg:golang/github.com/google/gofuzz@v1.0.0", "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421", "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742", "pkg:golang/github.com/stretchr/testify@v1.7.0" ]
+  }, {
+    "ref" : "pkg:golang/github.com/google/gofuzz@v1.0.0",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1", "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/multiformats/go-multihash@v0.0.15" ]
+  }, {
+    "ref" : "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+    "dependsOn" : [ "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2", "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3", "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4", "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2" ]
+  }, {
+    "ref" : "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+    "dependsOn" : [ ]
+  }, {
+    "ref" : "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+    "dependsOn" : [ ]
+  } ]
 }


### PR DESCRIPTION
## Summary

- Fix `HashMap.put()` collision in `getFinalPackagesVersionsForModule()` that dropped transitive dependencies when multiple parent module versions remapped to the same MVS-selected version
- Replace `put()` with `merge()` using `LinkedHashSet` to combine children lists while deduplicating
- Add reproducer test confirming 138 components (matching JS client), up from 134

Implements [TC-4127](https://redhat.atlassian.net/browse/TC-4127)

## Test plan

- [x] Reproducer test `Test_Golang_MvS_Enabled_Preserves_All_Transitive_Dependencies` passes (138 components)
- [x] Existing `Test_Golang_MvS_Logic_Disabled` passes (5 opencensus versions disabled, 1 enabled)
- [x] All 6 parameterized `test_the_provideStack` + `test_the_provideComponent` tests pass
- [x] All Go module tests pass (12/12 in surefire)
- [x] Spotless formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4127]: https://redhat.atlassian.net/browse/TC-4127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ