### PR TITLE
ci: suppress dependabot updates for test fixture manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
+# yaml-language-server: $schema=https://www.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
+  # ── Production dependencies ──────────────────────────────────────────
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -10,41 +12,68 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  # Prevent Dependabot from scanning test fixture manifests.
-  # These contain intentionally pinned (and sometimes vulnerable)
-  # dependencies used as test data for the dependency-analysis client.
+
+  # ── Test fixture manifests (suppress all updates including security) ─
+  # These directories contain intentionally pinned dependencies used as
+  # test fixtures. They must NOT be updated by dependabot.
+  - package-ecosystem: "maven"
+    directories:
+      - "/src/test/resources/tst_manifests/maven/**"
+      - "/src/test/resources/tst_manifests/it/maven/**"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/src/test/resources/tst_manifests/npm/**"
+      - "/src/test/resources/tst_manifests/pnpm/**"
+      - "/src/test/resources/tst_manifests/yarn-berry/**"
+      - "/src/test/resources/tst_manifests/yarn-classic/**"
+      - "/src/test/resources/tst_manifests/it/npm/**"
+      - "/src/test/resources/tst_manifests/it/pnpm/**"
+      - "/src/test/resources/tst_manifests/it/yarn/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "src/test/**"
-    open-pull-requests-limit: 0
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/src/test/resources/tst_manifests/pip/**"
+      - "/src/test/resources/tst_manifests/it/pypi/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "src/test/**"
-    open-pull-requests-limit: 0
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/src/test/resources/tst_manifests/golang/**"
+      - "/src/test/resources/tst_manifests/it/golang/**"
+      - "/src/test/resources/msc/golang/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "src/test/**"
-    open-pull-requests-limit: 0
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "gradle"
-    directory: "/"
+    directories:
+      - "/src/test/resources/tst_manifests/gradle-groovy/**"
+      - "/src/test/resources/tst_manifests/gradle-kotlin/**"
+      - "/src/test/resources/tst_manifests/it/gradle-groovy/**"
+      - "/src/test/resources/tst_manifests/it/gradle-kotlin/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "src/test/**"
-    open-pull-requests-limit: 0
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/src/test/resources/tst_manifests/cargo/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "src/test/**"
-    open-pull-requests-limit: 0
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Summary

- **Problem:** `exclude-paths` in `dependabot.yml` only applies to version updates, [not security updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#exclude-paths). This caused 8+ noisy PRs from dependabot trying to bump intentionally-pinned vulnerable deps in test fixture manifests under `src/test/resources/tst_manifests/` and `src/test/resources/msc/`.

- **Solution:** Add dedicated dependabot entries per ecosystem that target the test fixture directories with `ignore: [{dependency-name: "*"}]` to suppress both version and security update PRs ([ref](https://ovirium.com/blog/exclude-directory-from-dependabot-checks/)). The `ignore` option [supports security updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore) unlike `exclude-paths`.

### Changes

| Ecosystem | Change |
|---|---|
| maven (production) | Unchanged |
| maven (test fixtures) | New entry with `directories` targeting `tst_manifests/maven/**` + `it/maven/**` + `ignore: *` |
| npm (test fixtures) | Replaced `directory: "/"` + `exclude-paths` with `directories` targeting all JS test fixture dirs + `ignore: *` |
| pip | Replaced with targeted `directories` pointing to `pip/**` + `it/pypi/**` + `ignore: *` |
| gomod | Replaced with targeted `directories` pointing to `golang/**`, `it/golang/**`, `msc/golang/**` + `ignore: *` |
| gradle | Replaced with targeted `directories` pointing to `gradle-groovy/**`, `gradle-kotlin/**` + `it/` equivalents + `ignore: *` |
| cargo | Replaced with targeted `directories` pointing to `cargo/**` + `ignore: *` |

Mirrors guacsec/trustify-da-javascript-client#477.

## Test plan

- [ ] Verify dependabot stops creating PRs for test fixture manifests (check after next scan cycle)
- [ ] Verify production maven security/version updates still work
- [ ] Close existing 8 test fixture dependabot PRs after confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)