### PR TITLE
fix(cargo): propagate timeout error with actionable message

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/providers/CargoProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/CargoProvider.java
@@ -147,7 +147,8 @@ public final class CargoProvider extends Provider {
       }
 
     } catch (IOException | InterruptedException e) {
-      log.severe("Unexpected error during " + analysisType + " analysis: " + e.getMessage());
+      throw new RuntimeException(
+          "Failed during " + analysisType + " analysis: " + e.getMessage(), e);
     }
   }
 
@@ -438,7 +439,10 @@ public final class CargoProvider extends Provider {
         process.destroyForcibly();
         outputFuture.cancel(true);
         errorFuture.cancel(true);
-        throw new InterruptedException("cargo metadata timed out after " + TIMEOUT + " seconds");
+        throw new InterruptedException(
+            "cargo metadata timed out after "
+                + TIMEOUT
+                + " seconds. Adjust with -Dtrustify.cargo.timeout.seconds=N");
       }
 
       try {


### PR DESCRIPTION
## Summary

- Propagates timeout and I/O errors as `RuntimeException` instead of silently logging them, ensuring callers are notified of failures
- Adds system property hint (`-Dtrustify.cargo.timeout.seconds=N`) to timeout error message for easy adjustment

Implements [TC-4165](https://redhat.atlassian.net/browse/TC-4165)

## Test plan

- [x] All 29 existing Cargo tests pass (`CargoProviderTest`, `CargoSbomTest`)
- [x] Timeout error message includes system property hint
- [x] Errors propagate correctly through `addDependencies()` → `createSbom()` call chain
- [ ] CI integration tests pass on cargo-stable scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4165]: https://redhat.atlassian.net/browse/TC-4165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ