### PR TITLE
fix(python): add --quiet flag to pip report command

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/providers/PythonPyprojectProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/PythonPyprojectProvider.java
@@ -153,7 +153,9 @@ public final class PythonPyprojectProvider extends PythonProvider {
     }
 
     String pip = findPipBinary();
-    String[] cmd = {pip, "install", "--dry-run", "--ignore-installed", "--report", "-", "."};
+    String[] cmd = {
+      pip, "install", "--dry-run", "--ignore-installed", "--quiet", "--report", "-", "."
+    };
     Operations.ProcessExecOutput result =
         Operations.runProcessGetFullOutput(manifestDir, cmd, null);
     if (result.getExitCode() != 0) {


### PR DESCRIPTION
## Summary

- Adds `--quiet` flag to the `pip install --dry-run --report` command in `PythonPyprojectProvider` to suppress progress messages (e.g. `Processing /path/...`) from contaminating the JSON report on stdout
- Aligns with the JS client counterpart which already uses `--quiet` (`trustify-da-javascript-client/src/providers/python_pip_pyproject.js`)

Implements [TC-4164](https://redhat.atlassian.net/browse/TC-4164)

## Test plan

- [x] All existing Python provider tests pass
- [x] CI integration test `python-3.12-pyproject` passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4164]: https://redhat.atlassian.net/browse/TC-4164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ