### PR TITLE
ci: fix dependabot exclusions for non-production ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,52 @@ updates:
     schedule:
       interval: "weekly"
 
+  # ── Non-production ecosystems (no real deps, suppress everything) ────
+  # The repo has no production npm/pip/go/gradle/cargo dependencies.
+  # A root-level ignore-all entry ensures security updates are also
+  # suppressed, since per-directory entries with globs don't reliably
+  # block them.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+
   # ── Test fixture manifests (suppress all updates including security) ─
   # These directories contain intentionally pinned dependencies used as
   # test fixtures. They must NOT be updated by dependabot.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,7 @@ updates:
     directories:
       - "/src/test/resources/tst_manifests/pip/**"
       - "/src/test/resources/tst_manifests/it/pypi/**"
+      - "/src/test/resources/msc/python"
     schedule:
       interval: "monthly"
     labels: []


### PR DESCRIPTION
## Summary
- Add root-level `ignore: [{dependency-name: "*"}]` entries for all non-production ecosystems (npm, pip, gomod, gradle, cargo) to suppress security updates that bypass per-directory glob matching
- Add `/src/test/resources/msc/python` to the `pip` ecosystem exclusion (missed in #422)

### Why root-level entries?

Per-directory entries with `/**` globs don't reliably suppress **security updates** — PRs #424, #426, #427 (axios bumps in `it/npm`, `it/pnpm`, `it/yarn`) were all created **after** #422 was merged. Since this repo has no production npm/pip/go/gradle/cargo dependencies, root-level entries with `ignore-all` + `open-pull-requests-limit: 0` act as a catch-all.

The existing per-directory entries are kept for version update suppression.

## Test plan
- [ ] Verify no new dependabot PRs are created for test fixture manifests after the next scan cycle
- [ ] Close stale PRs #424, #425, #426, #427 after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)