### PR TITLE
ci: use GitHub App token for release bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,18 @@ jobs:
           # Run the phase that triggers README.md update
           mvn -B validate
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - name: Create Pull Request with next version
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "build(release): update to next development version"
           branch: chore/bump-version
           title: "chore: bump to next development version"


### PR DESCRIPTION
## Summary
- Post-release version bump PRs created by `github-actions[bot]` using `GITHUB_TOKEN` don't trigger CI checks (GitHub's anti-recursion protection)
- Use `actions/create-github-app-token@v2` with the installed GitHub App (`CI_APP_ID` / `CI_APP_PRIVATE_KEY` secrets) to generate a token
- Pass this token to `peter-evans/create-pull-request@v8` so the resulting PR triggers the "Build and test Java 21" workflow

## Test plan
- [ ] Trigger a release via `workflow_dispatch` and verify the bump PR triggers the Build check
- [ ] Verify the PR is created by the GitHub App identity, not `github-actions[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add a workflow step to generate a GitHub App token from CI_APP_ID and CI_APP_PRIVATE_KEY secrets and use it for the release bump pull request.