### PR TITLE
feat(workspace): add uv workspace discovery (TC-4266)

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/impl/ExhortApi.java
+++ b/src/main/java/io/github/guacsec/trustifyda/impl/ExhortApi.java
@@ -851,7 +851,8 @@ public final class ExhortApi implements Api {
   }
 
   private static final Set<String> DEFAULT_WORKSPACE_DISCOVERY_IGNORE =
-      Set.of("**/node_modules/**", "**/.git/**", "**/target/**", "**/__pycache__/**", "**/.venv/**");
+      Set.of(
+          "**/node_modules/**", "**/.git/**", "**/target/**", "**/__pycache__/**", "**/.venv/**");
 
   /** Merges default ignore patterns, env var overrides, and caller-provided patterns. */
   Set<String> resolveIgnorePatterns(Set<String> callerPatterns) {
@@ -1023,27 +1024,12 @@ public final class ExhortApi implements Api {
         return Collections.emptyList();
       }
 
-      List<String> memberPatterns = new ArrayList<>();
-      for (int i = 0; i < membersArray.size(); i++) {
-        String pattern = membersArray.getString(i);
-        if (pattern != null && !pattern.isBlank()) {
-          memberPatterns.add(pattern.trim());
-        }
-      }
+      List<String> memberPatterns = toStringList(membersArray);
       if (memberPatterns.isEmpty()) {
         return Collections.emptyList();
       }
 
-      Set<String> excludePatterns = new java.util.HashSet<>();
-      TomlArray excludeArray = workspaceConfig.getArray("exclude");
-      if (excludeArray != null) {
-        for (int i = 0; i < excludeArray.size(); i++) {
-          String pattern = excludeArray.getString(i);
-          if (pattern != null && !pattern.isBlank()) {
-            excludePatterns.add(pattern.trim());
-          }
-        }
-      }
+      List<String> excludePatterns = toStringList(workspaceConfig.getArray("exclude"));
 
       List<PathMatcher> memberMatchers =
           memberPatterns.stream()
@@ -1082,6 +1068,20 @@ public final class ExhortApi implements Api {
       LOG.log(Level.WARNING, "Failed to discover uv workspace members", e);
       return Collections.emptyList();
     }
+  }
+
+  static List<String> toStringList(TomlArray array) {
+    if (array == null) {
+      return List.of();
+    }
+    List<String> result = new ArrayList<>();
+    for (int i = 0; i < array.size(); i++) {
+      String s = array.getString(i);
+      if (s != null && !s.isBlank()) {
+        result.add(s.trim());
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/io/github/guacsec/trustifyda/impl/ExhortApi.java
+++ b/src/main/java/io/github/guacsec/trustifyda/impl/ExhortApi.java
@@ -37,6 +37,7 @@ import io.github.guacsec.trustifyda.providers.rust.model.CargoMetadata;
 import io.github.guacsec.trustifyda.tools.Ecosystem;
 import io.github.guacsec.trustifyda.tools.Operations;
 import io.github.guacsec.trustifyda.utils.Environment;
+import io.github.guacsec.trustifyda.utils.PyprojectTomlUtils;
 import io.github.guacsec.trustifyda.utils.WorkspaceUtils;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMultipart;
@@ -51,8 +52,10 @@ import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap;
@@ -68,8 +71,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
 
 /** Concrete implementation of the Exhort {@link Api} Service. */
 public final class ExhortApi implements Api {
@@ -844,7 +851,7 @@ public final class ExhortApi implements Api {
   }
 
   private static final Set<String> DEFAULT_WORKSPACE_DISCOVERY_IGNORE =
-      Set.of("**/node_modules/**", "**/.git/**", "**/target/**");
+      Set.of("**/node_modules/**", "**/.git/**", "**/target/**", "**/__pycache__/**", "**/.venv/**");
 
   /** Merges default ignore patterns, env var overrides, and caller-provided patterns. */
   Set<String> resolveIgnorePatterns(Set<String> callerPatterns) {
@@ -892,6 +899,15 @@ public final class ExhortApi implements Api {
       List<Path> mavenManifests = discoverMavenModules(workspaceDir, ignorePatterns);
       if (!mavenManifests.isEmpty()) {
         return mavenManifests;
+      }
+    }
+
+    // uv workspace: pyproject.toml with [tool.uv.workspace] + uv.lock
+    if (Files.isRegularFile(workspaceDir.resolve("pyproject.toml"))
+        && Files.isRegularFile(workspaceDir.resolve("uv.lock"))) {
+      List<Path> uvManifests = discoverUvWorkspaceMembers(workspaceDir, ignorePatterns);
+      if (!uvManifests.isEmpty()) {
+        return uvManifests;
       }
     }
 
@@ -983,6 +999,87 @@ public final class ExhortApi implements Api {
       return WorkspaceUtils.filterByIgnorePatterns(workspaceDir, manifests, ignorePatterns);
     } catch (Exception e) {
       LOG.warning("Failed to discover Go workspace modules: " + e.getMessage());
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Discover all pyproject.toml manifest paths in a uv workspace. Parses the root pyproject.toml
+   * for {@code [tool.uv.workspace]} member and exclude globs, then walks the filesystem to find
+   * matching member directories.
+   */
+  private List<Path> discoverUvWorkspaceMembers(Path workspaceDir, Set<String> ignorePatterns) {
+    try {
+      Path rootPyproject = workspaceDir.resolve("pyproject.toml");
+      TomlParseResult toml = PyprojectTomlUtils.parseToml(rootPyproject);
+
+      TomlTable workspaceConfig = toml.getTable("tool.uv.workspace");
+      if (workspaceConfig == null) {
+        return Collections.emptyList();
+      }
+
+      TomlArray membersArray = workspaceConfig.getArray("members");
+      if (membersArray == null || membersArray.isEmpty()) {
+        return Collections.emptyList();
+      }
+
+      List<String> memberPatterns = new ArrayList<>();
+      for (int i = 0; i < membersArray.size(); i++) {
+        String pattern = membersArray.getString(i);
+        if (pattern != null && !pattern.isBlank()) {
+          memberPatterns.add(pattern.trim());
+        }
+      }
+      if (memberPatterns.isEmpty()) {
+        return Collections.emptyList();
+      }
+
+      Set<String> excludePatterns = new java.util.HashSet<>();
+      TomlArray excludeArray = workspaceConfig.getArray("exclude");
+      if (excludeArray != null) {
+        for (int i = 0; i < excludeArray.size(); i++) {
+          String pattern = excludeArray.getString(i);
+          if (pattern != null && !pattern.isBlank()) {
+            excludePatterns.add(pattern.trim());
+          }
+        }
+      }
+
+      List<PathMatcher> memberMatchers =
+          memberPatterns.stream()
+              .map(p -> FileSystems.getDefault().getPathMatcher("glob:" + p))
+              .toList();
+
+      List<PathMatcher> excludeMatchers =
+          excludePatterns.stream()
+              .map(p -> FileSystems.getDefault().getPathMatcher("glob:" + p))
+              .toList();
+
+      List<Path> manifests = new ArrayList<>();
+      try (var stream = Files.walk(workspaceDir)) {
+        stream
+            .filter(p -> p.getFileName().toString().equals("pyproject.toml"))
+            .filter(p -> !p.equals(rootPyproject))
+            .forEach(
+                p -> {
+                  Path relative = workspaceDir.relativize(p.getParent());
+                  boolean matchesMember =
+                      memberMatchers.stream().anyMatch(m -> m.matches(relative));
+                  boolean matchesExclude =
+                      excludeMatchers.stream().anyMatch(m -> m.matches(relative));
+                  if (matchesMember && !matchesExclude) {
+                    manifests.add(p);
+                  }
+                });
+      }
+
+      if (PyprojectTomlUtils.getProjectName(toml) != null) {
+        manifests.addFirst(rootPyproject);
+      }
+
+      return WorkspaceUtils.filterByIgnorePatterns(workspaceDir, manifests, ignorePatterns);
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Failed to discover uv workspace members", e);
       return Collections.emptyList();
     }
   }

--- a/src/test/java/io/github/guacsec/trustifyda/impl/UvWorkspaceDiscoveryTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/impl/UvWorkspaceDiscoveryTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.guacsec.trustifyda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class UvWorkspaceDiscoveryTest {
+
+  private static final Path UV_FIXTURES = Path.of("src/test/resources/tst_manifests/workspace/uv");
+
+  @Test
+  void discoverWorkspaceManifests_uvRootPackageWorkspace() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).hasSize(3);
+    assertThat(manifests).allMatch(p -> p.toString().endsWith("pyproject.toml"));
+    assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pyproject.toml"));
+    assertThat(manifests)
+        .anyMatch(
+            p ->
+                p.toString()
+                    .contains(
+                        "packages"
+                            + File.separator
+                            + "mid-pkg"
+                            + File.separator
+                            + "pyproject.toml"));
+    assertThat(manifests)
+        .anyMatch(
+            p ->
+                p.toString()
+                    .contains(
+                        "packages"
+                            + File.separator
+                            + "sub-pkg"
+                            + File.separator
+                            + "pyproject.toml"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_uvVirtualWorkspace() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace_virtual").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).hasSize(2);
+    assertThat(manifests).allMatch(p -> p.toString().endsWith("pyproject.toml"));
+    assertThat(manifests).noneMatch(p -> p.equals(workspaceDir.resolve("pyproject.toml")));
+    assertThat(manifests).anyMatch(p -> p.toString().contains("pkg-a"));
+    assertThat(manifests).anyMatch(p -> p.toString().contains("pkg-b"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_uvExcludePatterns() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace_exclude").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).anyMatch(p -> p.toString().contains("core"));
+    assertThat(manifests).noneMatch(p -> p.toString().contains("internal"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_uvNestedMultiplePatterns() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace_nested").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests)
+        .anyMatch(
+            p ->
+                p.toString()
+                    .contains(
+                        "apps" + File.separator + "backend" + File.separator + "pyproject.toml"));
+    assertThat(manifests)
+        .anyMatch(
+            p ->
+                p.toString()
+                    .contains(
+                        "libs" + File.separator + "core" + File.separator + "pyproject.toml"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_uvNoLockFile() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace_no_lock").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).isEmpty();
+  }
+
+  @Test
+  void discoverWorkspaceManifests_uvNoWorkspaceConfig() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace_no_config").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).isEmpty();
+  }
+
+  @Test
+  void discoverWorkspaceManifests_uvIgnorePatternFiltering() throws IOException {
+    Path workspaceDir = UV_FIXTURES.resolve("uv_workspace_nested").toAbsolutePath().normalize();
+
+    ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of("**/libs/**"));
+
+    assertThat(manifests).anyMatch(p -> p.toString().contains("backend"));
+    assertThat(manifests)
+        .noneMatch(p -> p.toString().contains(File.separator + "libs" + File.separator));
+  }
+}

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace/packages/mid-pkg/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace/packages/mid-pkg/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "mid-pkg"
+version = "0.1.0"
+dependencies = [
+	"sub-pkg",
+]
+
+[tool.uv.sources]
+sub-pkg = { workspace = true }

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace/packages/sub-pkg/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace/packages/sub-pkg/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "sub-pkg"
+version = "0.1.0"
+dependencies = [
+    "requests>=2.0",
+]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "uv-mono"
+version = "0.1.0"
+dependencies = [
+	"mid-pkg",
+	"flask==2.0.3"
+]
+
+[tool.uv.sources]
+mid-pkg = { workspace = true }
+
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace/uv.lock
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/packages/core/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/packages/core/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "core"
+version = "0.1.0"
+dependencies = []

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/packages/internal/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/packages/internal/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "internal"
+version = "0.1.0"
+dependencies = []

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "exclude-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["packages/*"]
+exclude = ["packages/internal"]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/uv.lock
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_exclude/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/apps/backend/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/apps/backend/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "backend"
+version = "0.1.0"
+dependencies = []

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/libs/core/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/libs/core/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "core"
+version = "0.1.0"
+dependencies = []

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "nested-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["apps/*", "libs/*"]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/uv.lock
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_nested/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_no_config/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_no_config/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "no-config"
+version = "0.1.0"
+dependencies = ["requests>=2.0"]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_no_config/uv.lock
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_no_config/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_no_lock/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_no_lock/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "no-lock-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/packages/pkg-a/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/packages/pkg-a/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pkg-a"
+version = "0.1.0"
+dependencies = []

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/packages/pkg-b/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/packages/pkg-b/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pkg-b"
+version = "0.1.0"
+dependencies = []

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/pyproject.toml
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/uv.lock
+++ b/src/test/resources/tst_manifests/workspace/uv/uv_workspace_virtual/uv.lock
@@ -1,0 +1,1 @@
+version = 1


### PR DESCRIPTION
## Summary
- Parse `[tool.uv.workspace]` member and exclude globs from `pyproject.toml` to discover workspace member manifests
- Virtual workspaces (no `[project]` section) correctly exclude root `pyproject.toml` from results
- Add `__pycache__` and `.venv` to default ignore patterns
- Reuse existing `PyprojectTomlUtils` and `WorkspaceUtils` for TOML parsing and ignore filtering

## Test plan
- [x] 7 unit tests covering root-package workspace, virtual workspace, exclude patterns, nested multi-glob patterns, no-lock, no-config, and ignore pattern filtering
- [x] All existing workspace tests continue to pass

[TC-4266](https://redhat.atlassian.net/browse/TC-4266)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4266]: https://redhat.atlassian.net/browse/TC-4266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for discovering Python uv workspaces during workspace manifest resolution and extend default ignore patterns.

New Features:
- Discover uv workspace member pyproject.toml files based on [tool.uv.workspace] configuration and uv.lock presence.
- Support both root-package and virtual uv workspaces when resolving workspace manifests.

Enhancements:
- Extend default workspace discovery ignore patterns to skip __pycache__ and .venv directories.

Tests:
- Add unit test coverage for uv workspace discovery including root, virtual, excluded, nested, missing-lock, missing-config, and ignore-pattern scenarios.