### PR TITLE
fix(workspace): parse actual XML output from mvn help:evaluate

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/impl/ExhortApi.java
+++ b/src/main/java/io/github/guacsec/trustifyda/impl/ExhortApi.java
@@ -44,6 +44,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.util.ByteArrayDataSource;
 import java.io.IOException;
+import java.io.StringReader;
 import java.net.InetSocketAddress;
 import java.net.ProxySelector;
 import java.net.URI;
@@ -75,9 +76,11 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.tomlj.TomlArray;
 import org.tomlj.TomlParseResult;
 import org.tomlj.TomlTable;
+import org.xml.sax.InputSource;
 
 /** Concrete implementation of the Exhort {@link Api} Service. */
 public final class ExhortApi implements Api {
@@ -1198,27 +1201,43 @@ public final class ExhortApi implements Api {
   }
 
   /**
-   * Parses the output of {@code mvn help:evaluate -Dexpression=project.modules} which returns a
-   * string like {@code [module-a, module-b]}.
+   * Parses the XML output of {@code mvn help:evaluate -Dexpression=project.modules}. The output
+   * format is {@code <strings><string>module-a</string><string>module-b</string></strings>}.
    *
    * @param raw the raw output string
    * @return list of module name strings
    */
   static List<String> parseMavenModuleList(String raw) {
-    if (raw == null || raw.isEmpty()) {
+    if (raw == null || raw.isEmpty() || "null".equals(raw.trim())) {
       return Collections.emptyList();
     }
-    // Expected format: [module-a, module-b, ...]
-    java.util.regex.Matcher matcher =
-        java.util.regex.Pattern.compile("^\\[(.+)]$").matcher(raw.trim());
-    if (!matcher.matches()) {
+    String trimmed = raw.trim();
+    if (!trimmed.startsWith("<strings")) {
       return Collections.emptyList();
     }
-    String inner = matcher.group(1);
-    return java.util.Arrays.stream(inner.split(","))
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
-        .toList();
+    try {
+      var factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      var builder = factory.newDocumentBuilder();
+      var doc = builder.parse(new InputSource(new StringReader(trimmed)));
+      var nodes = doc.getElementsByTagName("string");
+      List<String> modules = new ArrayList<>(nodes.getLength());
+      for (int i = 0; i < nodes.getLength(); i++) {
+        String text = nodes.item(i).getTextContent().trim();
+        if (!text.isEmpty()) {
+          modules.add(text);
+        }
+      }
+      return modules;
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Failed to parse Maven module list XML", e);
+      return Collections.emptyList();
+    }
   }
 
   /**

--- a/src/test/java/io/github/guacsec/trustifyda/impl/MavenWorkspaceDiscoveryIT.java
+++ b/src/test/java/io/github/guacsec/trustifyda/impl/MavenWorkspaceDiscoveryIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.guacsec.trustifyda.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("IntegrationTest")
+class MavenWorkspaceDiscoveryIT {
+
+  private static final Path MAVEN_FIXTURES =
+      Path.of("src/test/resources/tst_manifests/workspace/maven");
+
+  @BeforeAll
+  static void requireMaven() {
+    boolean mavenAvailable;
+    try {
+      Process p = new ProcessBuilder("mvn", "-v").redirectErrorStream(true).start();
+      mavenAvailable = p.waitFor() == 0;
+    } catch (Exception e) {
+      mavenAvailable = false;
+    }
+    Assumptions.assumeTrue(mavenAvailable, "mvn not available on PATH");
+  }
+
+  @Test
+  void discoverWorkspaceManifests_mavenMultiModule() throws IOException {
+    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_multi_module").toAbsolutePath().normalize();
+    ExhortApi api = new ExhortApi();
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).hasSize(3);
+    assertThat(manifests).allMatch(p -> p.getFileName().toString().equals("pom.xml"));
+    assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
+    assertThat(manifests).anyMatch(p -> p.toString().contains("module-a"));
+    assertThat(manifests).anyMatch(p -> p.toString().contains("module-b"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_nestedAggregator() throws IOException {
+    Path workspaceDir =
+        MAVEN_FIXTURES.resolve("maven_nested_aggregator").toAbsolutePath().normalize();
+    ExhortApi api = new ExhortApi();
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).hasSize(3);
+    assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
+    assertThat(manifests)
+        .anyMatch(p -> p.toString().contains("parent" + java.io.File.separator + "pom.xml"));
+    assertThat(manifests)
+        .anyMatch(
+            p ->
+                p.toString()
+                    .contains(
+                        "parent"
+                            + java.io.File.separator
+                            + "child"
+                            + java.io.File.separator
+                            + "pom.xml"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_noModules() throws IOException {
+    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_no_modules").toAbsolutePath().normalize();
+    ExhortApi api = new ExhortApi();
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).hasSize(1);
+    assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_missingModuleDirectory() throws IOException {
+    // Maven fails to read the POM when a declared module directory is missing,
+    // so graceful degradation returns only the root pom.xml.
+    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_missing_module").toAbsolutePath().normalize();
+    ExhortApi api = new ExhortApi();
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
+
+    assertThat(manifests).hasSize(1);
+    assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
+  }
+
+  @Test
+  void discoverWorkspaceManifests_ignorePatternFiltering() throws IOException {
+    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_multi_module").toAbsolutePath().normalize();
+    ExhortApi api = new ExhortApi();
+    List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of("**/module-b/**"));
+
+    assertThat(manifests).anyMatch(p -> p.toString().contains("module-a"));
+    assertThat(manifests).noneMatch(p -> p.toString().contains("module-b"));
+  }
+}

--- a/src/test/java/io/github/guacsec/trustifyda/impl/MavenWorkspaceDiscoveryTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/impl/MavenWorkspaceDiscoveryTest.java
@@ -40,26 +40,16 @@ class MavenWorkspaceDiscoveryTest {
   /** Verifies that a standard module list output is parsed correctly. */
   @Test
   void parseMavenModuleList_standardOutput() {
-    // Given a typical mvn help:evaluate output
-    String raw = "[module-a, module-b]";
-
-    // When parsing
+    String raw = "<strings>\n  <string>module-a</string>\n  <string>module-b</string>\n</strings>";
     List<String> result = ExhortApi.parseMavenModuleList(raw);
-
-    // Then both modules are returned
     assertThat(result).containsExactly("module-a", "module-b");
   }
 
   /** Verifies that a single module is parsed correctly. */
   @Test
   void parseMavenModuleList_singleModule() {
-    // Given output with one module
-    String raw = "[parent]";
-
-    // When parsing
+    String raw = "<strings>\n  <string>parent</string>\n</strings>";
     List<String> result = ExhortApi.parseMavenModuleList(raw);
-
-    // Then the single module is returned
     assertThat(result).containsExactly("parent");
   }
 
@@ -78,221 +68,41 @@ class MavenWorkspaceDiscoveryTest {
   /** Verifies that 'null' string (no modules) returns an empty list. */
   @Test
   void parseMavenModuleList_nullString() {
-    // "null" is returned by mvn when there are no modules
     assertThat(ExhortApi.parseMavenModuleList("null")).isEmpty();
   }
 
-  /** Verifies that malformed output (no brackets) returns an empty list. */
+  /** Verifies that a {@code <modules/>} tag returns an empty list. */
   @Test
-  void parseMavenModuleList_malformedOutput() {
+  void parseMavenModuleList_emptyModulesTag() {
+    assertThat(ExhortApi.parseMavenModuleList("<modules/>")).isEmpty();
+  }
+
+  /** Verifies that malformed XML returns an empty list. */
+  @Test
+  void parseMavenModuleList_malformedXml() {
+    assertThat(ExhortApi.parseMavenModuleList("<strings><unclosed>")).isEmpty();
+  }
+
+  /** Verifies that non-XML input returns an empty list. */
+  @Test
+  void parseMavenModuleList_nonXmlInput() {
     assertThat(ExhortApi.parseMavenModuleList("module-a, module-b")).isEmpty();
   }
 
   /** Verifies that whitespace around module names is trimmed. */
   @Test
   void parseMavenModuleList_withWhitespace() {
-    // Given output with extra whitespace
-    String raw = "[  module-a ,  module-b  ]";
-
-    // When parsing
+    String raw =
+        "<strings>\n  <string>  module-a  </string>\n  <string>  module-b  </string>\n</strings>";
     List<String> result = ExhortApi.parseMavenModuleList(raw);
-
-    // Then modules are trimmed
     assertThat(result).containsExactly("module-a", "module-b");
   }
 
   // --- discoverWorkspaceManifests tests (require mocking Operations) ---
 
-  /** Verifies that a multi-module Maven project discovers all module pom.xml files. */
-  @Test
-  void discoverWorkspaceManifests_mavenMultiModule() throws IOException {
-    // Given a multi-module Maven workspace
-    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_multi_module").toAbsolutePath().normalize();
-
-    try (MockedStatic<Operations> mockOps = Mockito.mockStatic(Operations.class)) {
-      // Mock Maven binary resolution
-      mockOps.when(() -> Operations.getWrapperPreference("mvn")).thenReturn(false);
-      mockOps.when(() -> Operations.isWindows()).thenReturn(false);
-      mockOps.when(() -> Operations.getExecutable("mvn", "-v")).thenReturn("mvn");
-
-      // Mock mvn help:evaluate for root pom -> returns [module-a, module-b]
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("[module-a, module-b]", "", 0));
-
-      // Mock mvn help:evaluate for module-a -> returns null (leaf module)
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir.resolve("module-a")), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // Mock mvn help:evaluate for module-b -> returns null (leaf module)
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir.resolve("module-b")), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // When discovering workspace manifests
-      ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
-      List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
-
-      // Then root + 2 modules = 3 pom.xml files
-      assertThat(manifests).hasSize(3);
-      assertThat(manifests).allMatch(p -> p.getFileName().toString().equals("pom.xml"));
-      assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
-      assertThat(manifests).anyMatch(p -> p.toString().contains("module-a"));
-      assertThat(manifests).anyMatch(p -> p.toString().contains("module-b"));
-    }
-  }
-
-  /** Verifies that nested aggregator modules are discovered recursively. */
-  @Test
-  void discoverWorkspaceManifests_nestedAggregator() throws IOException {
-    // Given a nested Maven aggregator workspace
-    Path workspaceDir =
-        MAVEN_FIXTURES.resolve("maven_nested_aggregator").toAbsolutePath().normalize();
-
-    try (MockedStatic<Operations> mockOps = Mockito.mockStatic(Operations.class)) {
-      mockOps.when(() -> Operations.getWrapperPreference("mvn")).thenReturn(false);
-      mockOps.when(() -> Operations.isWindows()).thenReturn(false);
-      mockOps.when(() -> Operations.getExecutable("mvn", "-v")).thenReturn("mvn");
-
-      // Root -> [parent]
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("[parent]", "", 0));
-
-      // parent -> [child]
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir.resolve("parent").toAbsolutePath().normalize()),
-                      any(String[].class),
-                      isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("[child]", "", 0));
-
-      // child -> null (leaf)
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(
-                          workspaceDir
-                              .resolve("parent")
-                              .resolve("child")
-                              .toAbsolutePath()
-                              .normalize()),
-                      any(String[].class),
-                      isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // When discovering workspace manifests
-      ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
-      List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
-
-      // Then root + parent + child = 3 pom.xml files
-      assertThat(manifests).hasSize(3);
-      assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
-      assertThat(manifests)
-          .anyMatch(p -> p.toString().contains("parent" + java.io.File.separator + "pom.xml"));
-      assertThat(manifests)
-          .anyMatch(
-              p ->
-                  p.toString()
-                      .contains(
-                          "parent"
-                              + java.io.File.separator
-                              + "child"
-                              + java.io.File.separator
-                              + "pom.xml"));
-    }
-  }
-
-  /** Verifies that a project with no modules returns only the root pom.xml. */
-  @Test
-  void discoverWorkspaceManifests_noModules() throws IOException {
-    // Given a Maven project with no modules
-    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_no_modules").toAbsolutePath().normalize();
-
-    try (MockedStatic<Operations> mockOps = Mockito.mockStatic(Operations.class)) {
-      mockOps.when(() -> Operations.getWrapperPreference("mvn")).thenReturn(false);
-      mockOps.when(() -> Operations.isWindows()).thenReturn(false);
-      mockOps.when(() -> Operations.getExecutable("mvn", "-v")).thenReturn("mvn");
-
-      // Root -> null (no modules)
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // When discovering workspace manifests
-      ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
-      List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
-
-      // Then only the root pom.xml is returned
-      assertThat(manifests).hasSize(1);
-      assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
-    }
-  }
-
-  /** Verifies that missing module directories are skipped gracefully. */
-  @Test
-  void discoverWorkspaceManifests_missingModuleDirectory() throws IOException {
-    // Given a Maven project where one module directory is missing
-    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_missing_module").toAbsolutePath().normalize();
-
-    try (MockedStatic<Operations> mockOps = Mockito.mockStatic(Operations.class)) {
-      mockOps.when(() -> Operations.getWrapperPreference("mvn")).thenReturn(false);
-      mockOps.when(() -> Operations.isWindows()).thenReturn(false);
-      mockOps.when(() -> Operations.getExecutable("mvn", "-v")).thenReturn("mvn");
-
-      // Root -> [module-a, module-missing]
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("[module-a, module-missing]", "", 0));
-
-      // module-a -> null (leaf)
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir.resolve("module-a").toAbsolutePath().normalize()),
-                      any(String[].class),
-                      isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // When discovering workspace manifests
-      ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
-      List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
-
-      // Then root + module-a = 2 (module-missing is skipped)
-      assertThat(manifests).hasSize(2);
-      assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
-      assertThat(manifests).anyMatch(p -> p.toString().contains("module-a"));
-      assertThat(manifests).noneMatch(p -> p.toString().contains("module-missing"));
-    }
-  }
-
   /** Verifies that when mvn command fails, the root pom.xml is still returned. */
   @Test
   void discoverWorkspaceManifests_mvnCommandFails() throws IOException {
-    // Given a Maven workspace where mvn invocation fails
     Path workspaceDir = MAVEN_FIXTURES.resolve("maven_multi_module").toAbsolutePath().normalize();
 
     try (MockedStatic<Operations> mockOps = Mockito.mockStatic(Operations.class)) {
@@ -300,7 +110,6 @@ class MavenWorkspaceDiscoveryTest {
       mockOps.when(() -> Operations.isWindows()).thenReturn(false);
       mockOps.when(() -> Operations.getExecutable("mvn", "-v")).thenReturn("mvn");
 
-      // mvn command fails with non-zero exit code
       mockOps
           .when(
               () ->
@@ -308,62 +117,11 @@ class MavenWorkspaceDiscoveryTest {
                       eq(workspaceDir), any(String[].class), isNull()))
           .thenReturn(new Operations.ProcessExecOutput("", "error", 1));
 
-      // When discovering workspace manifests
       ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
       List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of());
 
-      // Then only the root pom.xml is returned (mvn failure falls through gracefully)
       assertThat(manifests).hasSize(1);
       assertThat(manifests.getFirst()).isEqualTo(workspaceDir.resolve("pom.xml"));
-    }
-  }
-
-  /** Verifies that ignore patterns filter out matched module paths. */
-  @Test
-  void discoverWorkspaceManifests_ignorePatternFiltering() throws IOException {
-    // Given a multi-module Maven workspace with an ignore pattern
-    Path workspaceDir = MAVEN_FIXTURES.resolve("maven_multi_module").toAbsolutePath().normalize();
-
-    try (MockedStatic<Operations> mockOps = Mockito.mockStatic(Operations.class)) {
-      mockOps.when(() -> Operations.getWrapperPreference("mvn")).thenReturn(false);
-      mockOps.when(() -> Operations.isWindows()).thenReturn(false);
-      mockOps.when(() -> Operations.getExecutable("mvn", "-v")).thenReturn("mvn");
-
-      // Root -> [module-a, module-b]
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir), any(String[].class), isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("[module-a, module-b]", "", 0));
-
-      // module-a -> null
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir.resolve("module-a").toAbsolutePath().normalize()),
-                      any(String[].class),
-                      isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // module-b -> null
-      mockOps
-          .when(
-              () ->
-                  Operations.runProcessGetFullOutput(
-                      eq(workspaceDir.resolve("module-b").toAbsolutePath().normalize()),
-                      any(String[].class),
-                      isNull()))
-          .thenReturn(new Operations.ProcessExecOutput("null", "", 0));
-
-      // When discovering with ignore pattern for module-b
-      ExhortApi api = new ExhortApi(Mockito.mock(java.net.http.HttpClient.class));
-      List<Path> manifests = api.discoverWorkspaceManifests(workspaceDir, Set.of("**/module-b/**"));
-
-      // Then module-b is filtered out
-      assertThat(manifests).anyMatch(p -> p.toString().contains("module-a"));
-      assertThat(manifests).noneMatch(p -> p.toString().contains("module-b"));
     }
   }
 


### PR DESCRIPTION
## Summary
- `mvn help:evaluate -Dexpression=project.modules` returns XML (`<strings><string>module-a</string>...</strings>`), not the bracket format (`[module-a, module-b]`) the original parser assumed
- Replaced regex-based bracket parser with XML DOM parser
- Cleaned up inline fully-qualified types into proper imports
- Replaced mocked integration tests with real Maven CLI integration tests

## Test plan
- [x] Verified actual `mvn help:evaluate` output against the multi-module test fixture
- [x] Unit tests pass (`MavenWorkspaceDiscoveryTest`)
- [x] Integration tests pass (`MavenWorkspaceDiscoveryIT`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Maven workspace discovery to handle actual XML output from Maven and validate it via real CLI integration tests.

New Features:
- Add Maven CLI-based integration tests for workspace manifest discovery across different multi-module layouts and ignore patterns.

Bug Fixes:
- Fix Maven module list parsing to correctly handle the XML format returned by `mvn help:evaluate -Dexpression=project.modules`, including empty and malformed inputs.

Enhancements:
- Simplify unit tests for Maven module list parsing to focus on XML-based scenarios and edge cases.
- Adjust behavior when Maven cannot resolve declared modules so that discovery degrades gracefully to the root pom where appropriate.

Tests:
- Replace mocked Maven workspace discovery tests with integration tests that run against real Maven projects using the Maven executable on PATH.