### PR TITLE
fix(cargo): resolve workspace-inherited license in Cargo.toml

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/providers/CargoProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/CargoProvider.java
@@ -71,6 +71,9 @@ public final class CargoProvider extends Provider {
   private static final String PACKAGE_VERSION = "package.version";
   private static final String PACKAGE_VERSION_WORKSPACE = "package.version.workspace";
   private static final String WORKSPACE_PACKAGE_VERSION = "workspace.package.version";
+  private static final String PACKAGE_LICENSE = "package.license";
+  private static final String PACKAGE_LICENSE_WORKSPACE = "package.license.workspace";
+  private static final String WORKSPACE_PACKAGE_LICENSE = "workspace.package.license";
   private static final long TIMEOUT =
       Long.parseLong(System.getProperty("trustify.cargo.timeout.seconds", "5"));
   private final String cargoExecutable;
@@ -671,7 +674,16 @@ public final class CargoProvider extends Provider {
       if (tomlResult.hasErrors()) {
         return null;
       }
-      String license = tomlResult.getString("package.license");
+      String license = null;
+      Object licenseValue = tomlResult.get(PACKAGE_LICENSE);
+      if (licenseValue instanceof String) {
+        license = (String) licenseValue;
+      } else if (licenseValue != null) {
+        Boolean isWorkspaceLicense = tomlResult.getBoolean(PACKAGE_LICENSE_WORKSPACE);
+        if (Boolean.TRUE.equals(isWorkspaceLicense)) {
+          license = tomlResult.getString(WORKSPACE_PACKAGE_LICENSE);
+        }
+      }
       return LicenseUtils.getLicense(license, manifestPath);
     } catch (IOException e) {
       log.warning("Failed to read license from Cargo.toml: " + e.getMessage());

--- a/src/test/java/io/github/guacsec/trustifyda/providers/CargoProviderLicenseTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/providers/CargoProviderLicenseTest.java
@@ -54,4 +54,20 @@ class CargoProviderLicenseTest extends ExhortTest {
     String license = provider.readLicenseFromManifest();
     assertThat(license).isNull();
   }
+
+  /** Verifies that workspace-inherited license resolves from [workspace.package]. */
+  @Test
+  void readLicenseFromManifest_returns_license_from_workspace_inheritance() {
+    var provider = createProvider("cargo_workspace_license_inheritance");
+    String license = provider.readLicenseFromManifest();
+    assertThat(license).isEqualTo("Apache-2.0");
+  }
+
+  /** Verifies graceful fallback when workspace inheritance has no license in workspace section. */
+  @Test
+  void readLicenseFromManifest_returns_null_when_workspace_inheritance_but_no_workspace_license() {
+    var provider = createProvider("cargo_workspace_license_inheritance_no_license");
+    String license = provider.readLicenseFromManifest();
+    assertThat(license).isNull();
+  }
 }

--- a/src/test/resources/tst_manifests/cargo/license/cargo_workspace_license_inheritance/Cargo.toml
+++ b/src/test/resources/tst_manifests/cargo/license/cargo_workspace_license_inheritance/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-project"
+version = "1.0.0"
+license = { workspace = true }
+
+[dependencies]
+serde = "1.0"
+
+[workspace.package]
+license = "Apache-2.0"

--- a/src/test/resources/tst_manifests/cargo/license/cargo_workspace_license_inheritance_no_license/Cargo.toml
+++ b/src/test/resources/tst_manifests/cargo/license/cargo_workspace_license_inheritance_no_license/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-project"
+version = "1.0.0"
+license = { workspace = true }
+
+[dependencies]
+serde = "1.0"
+
+[workspace.package]
+version = "1.0.0"


### PR DESCRIPTION
## Summary
- Detect Cargo workspace license inheritance (`license = { workspace = true }`) via `tomlj`'s `get()` method and resolve from `workspace.package.license`
- Follows the existing version workspace resolution pattern in `parseCargoToml()`
- Adds two new test cases: successful resolution and graceful null fallback

Fixes: [TC-4528](https://redhat.atlassian.net/browse/TC-4528)
Implements: [TC-4531](https://redhat.atlassian.net/browse/TC-4531)

## Test plan
- [x] New test: workspace license inheritance resolves to "Apache-2.0"
- [x] New test: workspace inheritance with no license in workspace section returns null
- [x] All 4 CargoProviderLicenseTest tests pass (0 failures)
- [x] All 358 tests pass (3 pre-existing GoModulesMainModuleVersionTest failures unrelated to this change)
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4528]: https://redhat.atlassian.net/browse/TC-4528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4531]: https://redhat.atlassian.net/browse/TC-4531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle Cargo workspace-inherited licenses when reading Cargo.toml manifests.

New Features:
- Support reading licenses inherited from Cargo workspaces via the package license workspace setting.

Tests:
- Add tests covering successful workspace license inheritance and null fallback when no workspace license is defined.