### PR TITLE
ci: onboard Codecov for unit test coverage tracking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
+      id-token: write
     env:
       MAIN_JAVA_VER: 21
       RUN_PYTHON_BIN: ${{ vars.RUN_PYTHON_BIN }}
@@ -66,9 +67,11 @@ jobs:
           ./target/surefire-reports/*.xml
           ./target/junit-platform/TEST-junit-jupiter.xml
 
-    - name: Upload coverage reports
+    - name: Upload coverage to Codecov
       if: ${{ matrix.java == env.MAIN_JAVA_VER }}
-      uses: actions/upload-artifact@v7
+      uses: codecov/codecov-action@v5
       with:
-        name: coverage-${{ matrix.java }}
-        path: ./target/site/jacoco/jacoco.xml
+        use_oidc: true
+        flags: unit-tests
+        files: ./target/site/jacoco/jacoco.xml
+        slug: guacsec/trustify-da-java-client

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,6 +72,5 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         use_oidc: true
-        flags: unit-tests
+        flags: integration-tests
         files: ./target/site/jacoco/jacoco.xml
-        slug: guacsec/trustify-da-java-client

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  require_ci_to_pass: false
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+flags:
+  unit-tests:
+    paths:
+      - src/main/java/
+    carryforward: true
+
+ignore:
+  - "src/test/"
+  - "src/main/resources/"
+  - "target/"
+  - "docs/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,7 @@ coverage:
         informational: true
 
 flags:
-  unit-tests:
+  integration-tests:
     paths:
       - src/main/java/
     carryforward: true


### PR DESCRIPTION
## Summary

- Add `codecov/codecov-action@v5` to the PR workflow with OIDC authentication (`use_oidc: true`) to upload JaCoCo coverage reports to [app.codecov.io](https://app.codecov.io)
- Replace the `actions/upload-artifact` step with the Codecov upload step, keeping the same matrix guard (`matrix.java == env.MAIN_JAVA_VER`)
- Add `id-token: write` permission at job level for OIDC token exchange
- Add `codecov.yml` with informational status checks, `unit-tests` flag with carryforward enabled, and ignore patterns for test/resource/build directories

## Details

The existing JaCoCo setup is already complete:
- Version 0.8.14 declared in `pluginManagement`
- `prepare-agent` and `check` goals in the main build plugins
- `report` goal in the `cov` profile (activated by `-Pcov`)
- Excludes configured for API model, exception, impl, and logging packages

No changes to `pom.xml` were needed.

## Test plan

- [ ] Verify the PR workflow runs successfully and the Codecov step uploads coverage
- [ ] Check that the Codecov status checks appear on the PR (informational, non-blocking)
- [ ] Confirm coverage report is visible at https://app.codecov.io/gh/guacsec/trustify-da-java-client

Ref: COVERPORT-253

## Summary by Sourcery

Integrate Codecov into the PR workflow to upload JaCoCo coverage for the main Java version and configure repository-wide coverage reporting behavior.

New Features:
- Introduce Codecov integration for tracking unit test coverage in the repository.

Enhancements:
- Add a Codecov configuration file to define informational project and patch status checks, a unit-test coverage flag with carryforward, and directory ignore rules for coverage calculations.

CI:
- Update the PR GitHub Actions workflow to upload JaCoCo coverage to Codecov using OIDC authentication for the main Java matrix entry.
- Grant id-token write permission in the PR workflow job to enable OIDC-based authentication for Codecov uploads.