### PR TITLE
build(deps): bump trustify-da-api-model from 2.0.8 to 2.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
     <!-- Dependencies -->
-    <trustify-da-api-model.version>2.0.8</trustify-da-api-model.version>
+    <trustify-da-api-model.version>2.0.9</trustify-da-api-model.version>
     <jackson.version>2.22.0</jackson.version>
     <jackson-annotations.version>2.22</jackson-annotations.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
## Summary

- Bump `trustify-da-api-model` dependency from 2.0.8 to 2.0.9 to pick up the new `unknown` severity field in `SourceSummary` and `UNKNOWN` value in the `Severity` enum

Implements [TC-4725](https://redhat.atlassian.net/browse/TC-4725)

## Test plan

- [x] `mvn spotless:apply` — no formatting changes needed
- [x] `mvn verify` — all tests pass (4 pre-existing Python_Provider_Test errors due to missing python3-devel headers, unrelated to this change)

[TC-4725]: https://redhat.atlassian.net/browse/TC-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ