### PR TITLE
fix(golang): reject // indirect //exhortignore as ignore marker

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
@@ -62,6 +62,14 @@ public final class GoModulesProvider extends Provider {
       "TRUSTIFY_DA_GO_MVS_LOGIC_ENABLED";
   private static final Logger log = LoggersFactory.getLogger(GoModulesProvider.class.getName());
   public static final String DEFAULT_MAIN_VERSION = "v0.0.0";
+
+  private static final Pattern STANDALONE_IGNORE_PATTERN =
+      Pattern.compile("(exhortignore|trustify-da-ignore)");
+  private static final Pattern INDIRECT_IGNORE_PATTERN =
+      Pattern.compile("indirect\\s*;\\s*(//)?\\s*(exhortignore|trustify-da-ignore)");
+  private static final Pattern DEPENDENCY_LINE_PATTERN =
+      Pattern.compile("^[a-z.0-9/-]+\\s{1,2}[vV][0-9]\\.[0-9](\\.[0-9]){0,2}.*");
+
   private final String goExecutable;
 
   public String getMainModuleVersion() {
@@ -569,8 +577,8 @@ public final class GoModulesProvider extends Provider {
         // "// indirect; // exhortignore").
         // Does NOT match "// indirect //exhortignore" (no semicolon) or
         // "// indirect exhortignore" (space-separated) — these are incorrect formats.
-        if (comment.matches("(exhortignore|trustify-da-ignore)")
-            || comment.matches("indirect\\s*;\\s*(//)?\\s*(exhortignore|trustify-da-ignore)")) {
+        if (STANDALONE_IGNORE_PATTERN.matcher(comment).matches()
+            || INDIRECT_IGNORE_PATTERN.matcher(comment).matches()) {
           // filter out lines where exhortignore or trustify-da-ignore has no meaning
           if (!trimmedRow.startsWith("module ")
               && !trimmedRow.startsWith("go ")
@@ -582,8 +590,7 @@ public final class GoModulesProvider extends Provider {
               && !trimmedRow.startsWith("use ")
               && !trimmedRow.contains("=>")) {
             if (trimmedRow.startsWith("require ")
-                || Pattern.matches(
-                    "^[a-z.0-9/-]+\\s{1,2}[vV][0-9]\\.[0-9](\\.[0-9]){0,2}.*", trimmedRow)) {
+                || DEPENDENCY_LINE_PATTERN.matcher(trimmedRow).matches()) {
               result = true;
             }
           }

--- a/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/providers/GoModulesProvider.java
@@ -560,32 +560,32 @@ public final class GoModulesProvider extends Provider {
   public boolean IgnoredLine(String line) {
     boolean result = false;
     if (IgnorePatternDetector.containsIgnorePattern(line)) {
-      // if exhortignore or trustify-da-ignore is alone in a comment or is in a comment together
-      // with indirect or as a
-      // comment inside a
-      // comment ( e.g // indirect  //exhort)
-      // then this line is to be checked if it's a comment after a package name.
-      if (Pattern.matches(".+//\\s*(exhortignore|trustify-da-ignore)", line)
-          || Pattern.matches(
-              ".+//\\s*indirect\\s*;\\s*(//)?\\s*(exhortignore|trustify-da-ignore)", line)) {
-        String trimmedRow = line.trim();
-        // filter out lines where exhortignore or trustify-da-ignore has no meaning
-        if (!trimmedRow.startsWith("module ")
-            && !trimmedRow.startsWith("go ")
-            && !trimmedRow.startsWith("require (")
-            && !trimmedRow.startsWith("require(")
-            && !trimmedRow.startsWith("exclude ")
-            && !trimmedRow.startsWith("replace ")
-            && !trimmedRow.startsWith("retract ")
-            && !trimmedRow.startsWith("use ")
-            && !trimmedRow.contains(
-                "=>")) { // only for lines that after trimming starts with "require " or starting
-          // with
-          // package name followd by one space, and then a semver version.
-          if (trimmedRow.startsWith("require ")
-              || Pattern.matches(
-                  "^[a-z.0-9/-]+\\s{1,2}[vV][0-9]\\.[0-9](\\.[0-9]){0,2}.*", trimmedRow)) {
-            result = true;
+      String trimmedRow = line.trim();
+      int firstComment = trimmedRow.indexOf("//");
+      if (firstComment >= 0) {
+        String comment = trimmedRow.substring(firstComment + 2).trim();
+        // Match standalone ignore pattern (e.g. "// exhortignore") or
+        // semicolon-separated with indirect (e.g. "// indirect; exhortignore",
+        // "// indirect; // exhortignore").
+        // Does NOT match "// indirect //exhortignore" (no semicolon) or
+        // "// indirect exhortignore" (space-separated) — these are incorrect formats.
+        if (comment.matches("(exhortignore|trustify-da-ignore)")
+            || comment.matches("indirect\\s*;\\s*(//)?\\s*(exhortignore|trustify-da-ignore)")) {
+          // filter out lines where exhortignore or trustify-da-ignore has no meaning
+          if (!trimmedRow.startsWith("module ")
+              && !trimmedRow.startsWith("go ")
+              && !trimmedRow.startsWith("require (")
+              && !trimmedRow.startsWith("require(")
+              && !trimmedRow.startsWith("exclude ")
+              && !trimmedRow.startsWith("replace ")
+              && !trimmedRow.startsWith("retract ")
+              && !trimmedRow.startsWith("use ")
+              && !trimmedRow.contains("=>")) {
+            if (trimmedRow.startsWith("require ")
+                || Pattern.matches(
+                    "^[a-z.0-9/-]+\\s{1,2}[vV][0-9]\\.[0-9](\\.[0-9]){0,2}.*", trimmedRow)) {
+              result = true;
+            }
           }
         }
       }

--- a/src/test/java/io/github/guacsec/trustifyda/providers/Golang_Modules_Provider_Test.java
+++ b/src/test/java/io/github/guacsec/trustifyda/providers/Golang_Modules_Provider_Test.java
@@ -239,6 +239,13 @@ class Golang_Modules_Provider_Test extends ExhortTest {
         .isFalse();
     assertThat(provider.IgnoredLine("        github.com/foo/bar v1.0.0 // indirect exhortignore"))
         .isFalse();
+    // Double-slash without semicolon should NOT be recognized (TC-4345)
+    assertThat(
+            provider.IgnoredLine(
+                "        github.com/foo/bar v1.0.0 // indirect //trustify-da-ignore"))
+        .isFalse();
+    assertThat(provider.IgnoredLine("        github.com/foo/bar v1.0.0 // indirect //exhortignore"))
+        .isFalse();
     // New semicolon format should still be recognized
     assertThat(
             provider.IgnoredLine(


### PR DESCRIPTION
## Summary
- Fix greedy regex in `IgnoredLine` that incorrectly treated `// indirect //exhortignore` as an ignored dependency (TC-4345)
- Parse the first `//` comment and only accept standalone ignore markers (`// exhortignore`) or the semicolon-separated format (`// indirect; exhortignore`), matching the JavaScript client behavior
- Add test cases for the `// indirect //exhortignore` format

## Test plan
- [x] Existing `test_IgnoredLine_rejects_old_space_separated_indirect_format` passes with new assertions
- [ ] CI passes
- [ ] Verify with integration test `golang-go_mod_with_ignore[stack]` that Java and JS clients produce matching results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Go modules ignore-line detection to only treat standalone or semicolon-separated ignore markers as valid, and align behavior with the JavaScript client.

Bug Fixes:
- Prevent lines with the invalid "// indirect //exhortignore" or "// indirect //trustify-da-ignore" formats from being treated as ignored dependencies.

Tests:
- Extend IgnoredLine tests to cover double-slash indirect formats and confirm they are not recognized while the semicolon format remains supported.