### PR TITLE
fix(image): gracefully handle missing Docker/Podman engine

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/image/ImageUtils.java
+++ b/src/main/java/io/github/guacsec/trustifyda/image/ImageUtils.java
@@ -281,10 +281,18 @@ public class ImageUtils {
     var exec = Operations.getCustomPathOrElse(engine);
     var cmd = new String[] {exec, "info"};
 
-    var output = Operations.runProcessGetFullOutput(null, cmd, null);
+    Operations.ProcessExecOutput output;
+    try {
+      output = Operations.runProcessGetFullOutput(null, cmd, null);
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof IOException) {
+        return "";
+      }
+      throw e;
+    }
     if (output.getOutput().isEmpty()
         && (!output.getError().isEmpty() || output.getExitCode() != 0)) {
-      throw new RuntimeException(output.getError());
+      return "";
     }
 
     return output

--- a/src/main/java/io/github/guacsec/trustifyda/image/ImageUtils.java
+++ b/src/main/java/io/github/guacsec/trustifyda/image/ImageUtils.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.packageurl.MalformedPackageURLException;
+import io.github.guacsec.trustifyda.logging.LoggersFactory;
 import io.github.guacsec.trustifyda.tools.Operations;
 import io.github.guacsec.trustifyda.utils.Environment;
 import java.io.File;
@@ -35,10 +36,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class ImageUtils {
+
+  private static final Logger LOG = LoggersFactory.getLogger(ImageUtils.class.getName());
 
   static final String TRUSTIFY_DA_SYFT_CONFIG_PATH = "TRUSTIFY_DA_SYFT_CONFIG_PATH";
   static final String TRUSTIFY_DA_SYFT_IMAGE_SOURCE = "TRUSTIFY_DA_SYFT_IMAGE_SOURCE";
@@ -286,6 +290,9 @@ public class ImageUtils {
       output = Operations.runProcessGetFullOutput(null, cmd, null);
     } catch (RuntimeException e) {
       if (e.getCause() instanceof IOException) {
+        LOG.warning(
+            String.format(
+                "Container engine '%s' not available: %s", exec, e.getCause().getMessage()));
         return "";
       }
       throw e;

--- a/src/test/java/io/github/guacsec/trustifyda/image/ImageUtilsTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/image/ImageUtilsTest.java
@@ -27,7 +27,6 @@ import static io.github.guacsec.trustifyda.image.ImageUtils.TRUSTIFY_DA_SYFT_IMA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
@@ -549,9 +548,8 @@ class ImageUtilsTest extends ExhortTest {
                       isNull(), aryEq(new String[] {"docker", "info"}), isNull()))
           .thenReturn(output);
 
-      var exception =
-          assertThrows(RuntimeException.class, () -> ImageUtils.hostInfo("docker", "info"));
-      assertEquals("test-error", exception.getMessage());
+      var result = ImageUtils.hostInfo("docker", "info");
+      assertEquals("", result);
     }
   }
 

--- a/src/test/java/io/github/guacsec/trustifyda/image/ImageUtilsTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/image/ImageUtilsTest.java
@@ -27,6 +27,8 @@ import static io.github.guacsec.trustifyda.image.ImageUtils.TRUSTIFY_DA_SYFT_IMA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
@@ -550,6 +552,27 @@ class ImageUtilsTest extends ExhortTest {
 
       var result = ImageUtils.hostInfo("docker", "info");
       assertEquals("", result);
+    }
+  }
+
+  @Test
+  void test_host_info_other_runtime_exceptions_propagate() {
+    try (MockedStatic<Operations> mock = Mockito.mockStatic(Operations.class)) {
+      RuntimeException expected = new RuntimeException("non-io-error");
+
+      mock.when(() -> Operations.getCustomPathOrElse(eq("docker"))).thenReturn("docker");
+
+      mock.when(() -> Operations.getExecutable(eq("docker"), any())).thenReturn("docker");
+
+      mock.when(
+              () ->
+                  Operations.runProcessGetFullOutput(
+                      isNull(), aryEq(new String[] {"docker", "info"}), isNull()))
+          .thenThrow(expected);
+
+      RuntimeException thrown =
+          assertThrows(RuntimeException.class, () -> ImageUtils.hostInfo("docker", "info"));
+      assertSame(expected, thrown);
     }
   }
 


### PR DESCRIPTION
## Summary
- `ImageUtils.hostInfo()` now returns an empty string instead of throwing `RuntimeException` when the container engine binary is missing (`IOException`) or returns error output
- This allows callers to fall back gracefully rather than crashing when neither Docker nor Podman is installed
- Updated test to assert empty string return instead of exception

## Test plan
- [ ] Verify image analysis works normally when Docker is available
- [ ] Verify image analysis degrades gracefully when neither Docker nor Podman is installed
- [ ] Run existing `ImageUtilsTest` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle missing container engine binaries gracefully when retrieving image host info.

Bug Fixes:
- Return an empty string from ImageUtils.hostInfo when the Docker/Podman binary is missing or returns only error output instead of throwing a RuntimeException.

Tests:
- Update ImageUtilsTest to assert an empty string result when no Docker path is available instead of expecting an exception.